### PR TITLE
Align yamllint with ansible-lint requirements

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -16,3 +16,12 @@ rules:
       - "true"
       - "false"
   document-end: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+    min-spaces-inside: 0
+  octal-values:
+    forbid-explicit-octal: true
+    forbid-implicit-octal: true


### PR DESCRIPTION
See `ansible-lint` [documentation](https://ansible.readthedocs.io/projects/lint/rules/yaml/?h=yamllint#yamllint-configuration) for details on the required yamllint configuration.