### PR TITLE
Allow installing gnome extensions

### DIFF
--- a/changelogs/fragments/user-config-gnome-extensions.yml
+++ b/changelogs/fragments/user-config-gnome-extensions.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - user_config role - add optional GNOME Shell extension installation

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,8 @@ authors:
 description: Fedora Linux system configuration and management
 license_file: LICENSE
 tags: ["linux", "tools", "fedora"]
-dependencies: {}
+dependencies:
+  "community.general": ">=8.0.0"
 
 repository: https://github.com/branic/system_management
 # documentation: http://docs.example.com

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -5,16 +5,18 @@ Configure per-user desktop settings for the **Ansible connection user**:
 - GTK 3 sidebar bookmarks
 - Slack Flatpak overrides
 - GNOME DConf keys
+- GNOME Shell extensions
 
 ## Requirements
 
 - Ansible **2.16+** (see `meta/main.yml`).
 - Collection **community.general** (DConf, templates; Flatpak-related paths are file-based).
+- Target systems must provide **`gnome-extensions`** (typically from the `gnome-shell` package) for GNOME Shell extensions.
 - Target systems where these settings apply (typically **Fedora** with GNOME).
 
 ## Facts and connection
 
-- Paths use **`ansible_user_dir`** (and `owner` / `group` from **`ansible_user`**). If `ansible_user_dir` is not already available (for example `gather_facts: false` in the play), the role runs `setup` with a minimal fact subset to define it.
+- Paths use **`ansible_facts['user_dir']`** (and `owner` / `group` from **`ansible_user`**). If `user_dir` is not in **`ansible_facts`** (for example `gather_facts: false` in the play), the role runs `setup` with a minimal fact subset to define it.
 - Run the play **as the user** whose home you are configuring (`ansible_user` / remote user). Using `become` to root and a different login user is not what this role is written for unless you also set facts accordingly.
 
 ## Role variables
@@ -25,7 +27,9 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | --- | --- |
 | `user_config_slack_flatpak_sockets` | If `true` (default), write Slack Flatpak socket overrides (system/session bus, Wayland; not X11). |
 | `user_config_slack_flatpak_filesystems` | Extra filesystem entries for the Slack override (list of strings); if empty, the `filesystems` line is omitted. |
+| `user_config_gtk_include_default_bookmarks` | If `true` (default), prepend GNOME-style XDG default bookmarks (`Documents`, `Downloads`, etc.) before `user_config_gtk_bookmarks`. Set `false` to manage only your explicit list. |
 | `user_config_gtk_bookmarks` | List of `path` (required) and optional `name` for GTK 3 `~/.config/gtk-3.0/bookmarks`. Paths may be `file://`, absolute, `~`, `~/`, or relative to the user home. |
+| `user_config_gnome_extensions` | GNOME Shell extensions to install. Each entry is a **dict** with at least one of `url` (direct HTTPS URL to the extension zip), `id` (extensions.gnome.org pk), or `name` (exact catalog name to search). Precedence is `url`, then `id`, then `name`. Optional `force` (pass `-f` to `gnome-extensions install`), optional `enable` (default `true`: `gnome-extensions enable`, or `disable` when `false`). Requires `gnome-extensions` and `gnome-shell` on the target. Bundles are downloaded to a **temporary directory** that is removed when extension tasks finish. |
 
 ## Dependencies
 

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -8,6 +8,13 @@ user_config_slack_flatpak_sockets: true
 # If empty or unset, the filesystems line is omitted from the override file.
 user_config_slack_flatpak_filesystems: []
 
+# When true, prepend GNOME-style default XDG bookmarks before user_config_gtk_bookmarks.
+user_config_gtk_include_default_bookmarks: true
+
 # GTK 3 sidebar bookmarks (~/.config/gtk-3.0/bookmarks). Each item: path (required), name (optional).
 # path: file:// URI, absolute path, ~ or ~/ (managed user's home), or path relative to that home.
 user_config_gtk_bookmarks: []
+
+# GNOME Shell extensions (see README). Each item is a dict with at least one of id, name, url.
+# Resolution order: url (if set) else id (if set) else name. Optional: enable (default true), force.
+user_config_gnome_extensions: []

--- a/roles/user_config/meta/argument_specs.yml
+++ b/roles/user_config/meta/argument_specs.yml
@@ -1,9 +1,9 @@
 ---
 argument_specs:
   main:
-    short_description: Per-user GTK, Flatpak overrides, and DConf preferences
+    short_description: Per-user configuration preferences
     description:
-      - Configures the Ansible connection user's home (GTK bookmarks, Slack Flatpak overrides, GNOME DConf keys).
+      - Configures the Ansible connection user's environment preferences.
     author:
       - Brant Evans
     options:
@@ -23,6 +23,13 @@ argument_specs:
           - Extra filesystem paths for the Slack Flatpak override (e.g. "~/tmp/", "xdg-documents").
           - When empty, the filesystems line is omitted from the override file.
 
+      user_config_gtk_include_default_bookmarks:
+        type: bool
+        required: false
+        default: true
+        description:
+          - When true, prepend GNOME default bookmarks before user_config_gtk_bookmarks.
+
       user_config_gtk_bookmarks:
         type: list
         elements: dict
@@ -40,3 +47,43 @@ argument_specs:
             type: str
             required: false
             description: Optional display name for the bookmark.
+
+      user_config_gnome_extensions:
+        type: list
+        elements: dict
+        required: false
+        default: []
+        description:
+          - GNOME Shell extensions to install with gnome-extensions.
+          - Each entry must include at least one of id, name, or url.
+          - Resolution precedence is url, then id, then name (if url is set, id and name are ignored for lookup).
+          - If both id and name are set without url, id is used.
+          - Extensions are resolved via extensions.gnome.org when using id or name; downloads use a temporary directory removed after the tasks complete.
+        options:
+          id:
+            type: int
+            required: false
+            description:
+              - Primary key of the extension on extensions.gnome.org (used when url is not set and id is set).
+          name:
+            type: str
+            required: false
+            description:
+              - Exact display name to search on extensions.gnome.org (used when url and id are not set).
+          url:
+            type: str
+            required: false
+            description:
+              - Direct HTTP(S) URL to the extension zip bundle (highest precedence when set).
+          enable:
+            type: bool
+            required: false
+            default: true
+            description:
+              - When true, run gnome-extensions enable after install; when false, run gnome-extensions disable.
+          force:
+            type: bool
+            required: false
+            default: false
+            description:
+              - When true, pass -f to gnome-extensions install and reinstall even if the catalog version is not newer.

--- a/roles/user_config/tasks/gnome_extensions.yml
+++ b/roles/user_config/tasks/gnome_extensions.yml
@@ -1,0 +1,122 @@
+---
+# GNOME Shell extensions: resolve via extensions.gnome.org (id/name) or direct URL, install with gnome-extensions.
+
+- name: gnome_extensions | Require gnome-extensions command
+  ansible.builtin.command:
+    argv:
+      - command
+      - -v
+      - gnome-extensions
+  register: __user_config_gnome_ext_cli_check
+  changed_when: false
+  failed_when: false
+
+- name: gnome_extensions | Fail when gnome-extensions is missing
+  ansible.builtin.fail:
+    msg: >-
+      The gnome-extensions command is required but was not found in PATH.
+      Install the package that provides it (typically gnome-shell).
+  when: __user_config_gnome_ext_cli_check.rc != 0
+
+- name: gnome_extensions | Get GNOME Shell version
+  ansible.builtin.command:
+    cmd: gnome-shell --version
+  register: __user_config_gnome_shell_version_cmd
+  changed_when: false
+
+- name: gnome_extensions | Set GNOME Shell version number
+  ansible.builtin.set_fact:
+    __user_config_gnome_shell_version: "{{ __user_config_gnome_shell_version_cmd.stdout | regex_search('\\d+\\.\\d+(?:\\.\\d+)?') }}"
+  when: __user_config_gnome_shell_version_cmd.rc == 0
+
+- name: gnome_extensions | Require GNOME Shell version
+  ansible.builtin.assert:
+    that:
+      - __user_config_gnome_shell_version | default('', true) is match('^\d+\.\d+(?:\.\d+)?$')
+    fail_msg: >-
+      Could not determine GNOME Shell version. Ensure gnome-shell is installed and
+      `gnome-shell --version` prints a version number (e.g. GNOME Shell 49.4).
+
+- name: gnome_extensions | Create temporary directory for extension bundles
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: ansible-gnome-ext-
+  register: __user_config_gnome_ext_tempdir_result
+
+- name: gnome_extensions | Set temporary directory path fact
+  ansible.builtin.set_fact:
+    __user_config_gnome_ext_tempdir: "{{ __user_config_gnome_ext_tempdir_result.path }}"
+
+- name: gnome_extensions | Reset enabled-extensions plan for this run
+  ansible.builtin.set_fact:
+    __user_config_gnome_ext_enabled_plan: []
+
+- name: gnome_extensions | Process GNOME extensions (Block)
+  block:
+    - name: gnome_extensions | Process each extension
+      ansible.builtin.include_tasks:
+        file: gnome_extensions_install_one.yml
+      loop: "{{ user_config_gnome_extensions }}"
+      loop_control:
+        loop_var: __user_config_gnome_ext_item
+        label: >-
+          {%- set _i = __user_config_gnome_ext_item -%}
+          {%- set _has_url = _i.url is defined and (_i.url | string | trim | length) > 0 -%}
+          {%- set _has_id = _i.id is defined and _i.id is not none and (_i.id | string | trim | length) > 0 -%}
+          {%- set _has_name = _i.name is defined and (_i.name | string | trim | length) > 0 -%}
+          {%- if _has_url -%}
+          {{- _i.url | string | trim -}}
+          {%- elif _has_name and _has_id -%}
+          {{- _i.name | string | trim }} ({{ _i.id }}){%- elif _has_name -%}
+          {{- _i.name | string | trim -}}
+          {%- elif _has_id -%}
+          {{- _i.id -}}
+          {%- endif -%}
+
+    # gnome-extensions enable/disable talk to the running Shell; if the extension is not
+    # registered yet, they no-op. org.gnome.shell enabled-extensions (dconf) persists across
+    # logout/reboot, so merge UUIDs there explicitly — one read/write, sorted for idempotency.
+    - name: gnome_extensions | Read enabled-extensions from dconf
+      community.general.dconf:
+        key: /org/gnome/shell/enabled-extensions
+        state: read
+      register: __user_config_ext_dconf_enabled_extensions
+
+    # dconf prints a GVariant text form that looks like ['a', 'b'] (single quotes) — valid YAML
+    # flow sequence, but not valid JSON (JSON requires double-quoted strings).
+    - name: gnome_extensions | Parse current enabled-extensions list
+      ansible.builtin.set_fact:
+        __uc_ext_enabled_list_current: "{{ __user_config_ext_dconf_enabled_extensions.value | default('[]', true) | from_yaml }}"
+
+    - name: gnome_extensions | Initialize merged enabled-extensions from dconf
+      ansible.builtin.set_fact:
+        __uc_ext_enabled_list_merged: "{{ __uc_ext_enabled_list_current }}"
+
+    - name: gnome_extensions | Merge playbook extension enable flags into list
+      ansible.builtin.set_fact:
+        __uc_ext_enabled_list_merged: >-
+          {{
+            (__uc_ext_enabled_list_merged | union([item.uuid]))
+            if (item.enable | bool) else
+            (__uc_ext_enabled_list_merged | difference([item.uuid]))
+          }}
+      loop: "{{ __user_config_gnome_ext_enabled_plan }}"
+      loop_control:
+        label: "{{ item.uuid }}"
+
+    - name: gnome_extensions | Order enabled-extensions deterministically
+      ansible.builtin.set_fact:
+        __uc_ext_enabled_list_final: "{{ __uc_ext_enabled_list_merged | sort }}"
+
+    - name: gnome_extensions | Persist enabled-extensions in dconf
+      community.general.dconf:
+        key: /org/gnome/shell/enabled-extensions
+        value: '{{ "[''" + (__uc_ext_enabled_list_final | join("'', ''")) + "'']" if __uc_ext_enabled_list_final | length > 0 else "[]" }}'
+        state: present
+
+  always:
+    - name: gnome_extensions | Remove temporary directory
+      ansible.builtin.file:
+        path: "{{ __user_config_gnome_ext_tempdir_result.path }}"
+        state: absent
+      when: __user_config_gnome_ext_tempdir_result.path | default('') | length > 0

--- a/roles/user_config/tasks/gnome_extensions_ego_by_id.yml
+++ b/roles/user_config/tasks/gnome_extensions_ego_by_id.yml
@@ -1,0 +1,10 @@
+---
+# Resolves an extension when the user supplied id (and not url). Requires loop item and shell version.
+
+- name: gnome_extensions_ego_by_id | Set EGO primary key from user id
+  ansible.builtin.set_fact:
+    __uc_ext_ego_pk: "{{ __user_config_gnome_ext_item.id | int }}"
+
+- name: gnome_extensions_ego_by_id | Load extension-info from extensions.gnome.org
+  ansible.builtin.include_tasks:
+    file: gnome_extensions_ego_extension_info.yml

--- a/roles/user_config/tasks/gnome_extensions_ego_by_name.yml
+++ b/roles/user_config/tasks/gnome_extensions_ego_by_name.yml
@@ -1,0 +1,39 @@
+---
+# Resolves an extension when the user supplied name only (no url, no id). Requires loop item and shell version.
+
+- name: gnome_extensions_ego_by_name | Search extensions by name
+  ansible.builtin.uri:
+    url: >-
+      https://extensions.gnome.org/extension-query/?search={{ __user_config_gnome_ext_item.name | trim | urlencode }}
+    return_content: true
+    status_code: [200]
+  register: __user_config_ext_ego_query
+
+- name: gnome_extensions_ego_by_name | Parse extension-query JSON
+  ansible.builtin.set_fact:
+    __uc_ext_ego_query_json: "{{ __user_config_ext_ego_query.json if __user_config_ext_ego_query.json is defined else (__user_config_ext_ego_query.content | from_json) }}"
+
+- name: gnome_extensions_ego_by_name | Filter exact name match (first in API order)
+  ansible.builtin.set_fact:
+    __uc_ext_name_matches: >-
+      {{
+        __uc_ext_ego_query_json.extensions | default([])
+        | selectattr('name', 'equalto', __user_config_gnome_ext_item.name | trim)
+        | list
+      }}
+
+- name: gnome_extensions_ego_by_name | Require a name search hit
+  ansible.builtin.assert:
+    that:
+      - __uc_ext_name_matches | length > 0
+    fail_msg: >-
+      No extension on extensions.gnome.org has the exact name
+      "{{ __user_config_gnome_ext_item.name | trim }}".
+
+- name: gnome_extensions_ego_by_name | Set EGO primary key from name search
+  ansible.builtin.set_fact:
+    __uc_ext_ego_pk: "{{ __uc_ext_name_matches[0].pk }}"
+
+- name: gnome_extensions_ego_by_name | Load extension-info from extensions.gnome.org
+  ansible.builtin.include_tasks:
+    file: gnome_extensions_ego_extension_info.yml

--- a/roles/user_config/tasks/gnome_extensions_ego_extension_info.yml
+++ b/roles/user_config/tasks/gnome_extensions_ego_extension_info.yml
@@ -1,0 +1,23 @@
+---
+# Requires __uc_ext_ego_pk and __user_config_gnome_shell_version (from parent loop).
+# Sets __user_config_ext_ego_info, __uc_ext_ego_json, __uc_ext_ego_uuid, __uc_ext_target_version, __uc_ext_full_download_url.
+
+- name: gnome_extensions_ego_extension_info | Query extension-info by pk
+  ansible.builtin.uri:
+    url: >-
+      https://extensions.gnome.org/extension-info/?pk={{ __uc_ext_ego_pk | int }}&shell_version={{ __user_config_gnome_shell_version }}
+    return_content: true
+    status_code: [200]
+  register: __user_config_ext_ego_info
+
+- name: gnome_extensions_ego_extension_info | Parse extension-info JSON
+  ansible.builtin.set_fact:
+    __uc_ext_ego_json: "{{ __user_config_ext_ego_info.json if __user_config_ext_ego_info.json is defined else (__user_config_ext_ego_info.content | from_json) }}"
+
+- name: gnome_extensions_ego_extension_info | Set facts from extension-info
+  ansible.builtin.set_fact:
+    __uc_ext_ego_uuid: "{{ __uc_ext_ego_json.uuid }}"
+    __uc_ext_target_version: "{{ __uc_ext_ego_json.version | int }}"
+    __uc_ext_full_download_url: "{{ _dl if (_dl is match('^https?://')) else ('https://extensions.gnome.org' ~ _dl) }}"
+  vars:
+    _dl: "{{ __uc_ext_ego_json.download_url | default('') | string }}"

--- a/roles/user_config/tasks/gnome_extensions_install_one.yml
+++ b/roles/user_config/tasks/gnome_extensions_install_one.yml
@@ -1,0 +1,250 @@
+---
+# One entry from user_config_gnome_extensions. Requires __user_config_gnome_ext_tempdir and __user_config_gnome_shell_version.
+
+- name: gnome_extensions_install_one | Require mapping entry
+  ansible.builtin.assert:
+    that:
+      - __user_config_gnome_ext_item is mapping
+    fail_msg: user_config_gnome_extensions entries must be dictionaries (id, name, and/or url).
+
+- name: gnome_extensions_install_one | Detect which keys are set
+  ansible.builtin.set_fact:
+    __uc_ext_has_url: >-
+      {{
+        __user_config_gnome_ext_item.url is defined
+        and (__user_config_gnome_ext_item.url | string | trim | length) > 0
+      }}
+    __uc_ext_has_id: >-
+      {{
+        __user_config_gnome_ext_item.id is defined
+        and __user_config_gnome_ext_item.id is not none
+        and (__user_config_gnome_ext_item.id | string | trim | length) > 0
+      }}
+    __uc_ext_has_name: >-
+      {{
+        __user_config_gnome_ext_item.name is defined
+        and (__user_config_gnome_ext_item.name | string | trim | length) > 0
+      }}
+
+- name: gnome_extensions_install_one | Require at least one of url, id, name
+  ansible.builtin.assert:
+    that:
+      - (__uc_ext_has_url | bool) or (__uc_ext_has_id | bool) or (__uc_ext_has_name | bool)
+    fail_msg: Each extension entry needs at least one of url, id, or name.
+
+- name: gnome_extensions_install_one | Common options
+  ansible.builtin.set_fact:
+    __uc_ext_force: "{{ __user_config_gnome_ext_item.force | default(false) | bool }}"
+    __uc_ext_enable: "{{ __user_config_gnome_ext_item.enable | default(true) | bool }}"
+
+- name: gnome_extensions_install_one | Reset per-iteration working facts
+  ansible.builtin.set_fact:
+    __uc_ext_full_download_url: ""
+    __uc_ext_ego_uuid: ""
+    __uc_ext_ego_pk: 0
+    __uc_ext_target_version: -1
+    __uc_ext_ego_json: {}
+    __uc_ext_ego_query_json: {}
+    __uc_ext_name_matches: []
+
+# --- Resolution: url > id > name ---
+
+- name: gnome_extensions_install_one | Resolve direct URL
+  when: __uc_ext_has_url | bool
+  ansible.builtin.set_fact:
+    __uc_ext_full_download_url: "{{ __user_config_gnome_ext_item.url | trim }}"
+    __uc_ext_ego_uuid: ""
+    __uc_ext_target_version: -1
+
+- name: gnome_extensions_install_one | Resolve extension via EGO id
+  when:
+    - not (__uc_ext_has_url | bool)
+    - __uc_ext_has_id | bool
+  ansible.builtin.include_tasks:
+    file: gnome_extensions_ego_by_id.yml
+
+- name: gnome_extensions_install_one | Resolve extension via EGO name search
+  when:
+    - not (__uc_ext_has_url | bool)
+    - not (__uc_ext_has_id | bool)
+    - __uc_ext_has_name | bool
+  ansible.builtin.include_tasks:
+    file: gnome_extensions_ego_by_name.yml
+
+- name: gnome_extensions_install_one | Require download_url from EGO when not using direct url
+  when: not (__uc_ext_has_url | bool)
+  ansible.builtin.assert:
+    that:
+      - ( __uc_ext_ego_json | default({}) ).download_url | default('') | string | length > 0
+    fail_msg: extensions.gnome.org did not return a download_url for this GNOME Shell version.
+
+- name: gnome_extensions_install_one | Require resolved download URL
+  ansible.builtin.assert:
+    that:
+      - __uc_ext_full_download_url | default('') | length > 0
+    fail_msg: Could not determine extension download URL.
+
+- name: gnome_extensions_install_one | Set local bundle path
+  ansible.builtin.set_fact:
+    __uc_ext_local_bundle: "{{ __user_config_gnome_ext_tempdir }}/ext-{{ __user_config_gnome_ext_item | to_json | hash('sha256') }}.zip"
+
+- name: gnome_extensions_install_one | Download extension bundle
+  ansible.builtin.get_url:
+    url: "{{ __uc_ext_full_download_url }}"
+    dest: "{{ __uc_ext_local_bundle }}"
+    mode: "0644"
+
+- name: gnome_extensions_install_one | Resolve UUID from extension bundle
+  when: __uc_ext_ego_uuid | default('') | length == 0
+  block:
+    - name: gnome_extensions_install_one | Read UUID from bundle when not from EGO
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - "import zipfile, json, sys; z = zipfile.ZipFile(sys.argv[1]); print(json.load(z.open('metadata.json'))['uuid'])"
+          - "{{ __uc_ext_local_bundle }}"
+      register: __user_config_ext_uuid_read
+      changed_when: false
+      check_mode: false
+
+    - name: gnome_extensions_install_one | Set UUID from bundle
+      ansible.builtin.set_fact:
+        __uc_ext_uuid: "{{ __user_config_ext_uuid_read.stdout | trim }}"
+
+- name: gnome_extensions_install_one | Set UUID from EGO
+  when: __uc_ext_ego_uuid | default('') | length > 0
+  ansible.builtin.set_fact:
+    __uc_ext_uuid: "{{ __uc_ext_ego_uuid }}"
+
+- name: gnome_extensions_install_one | Resolve version from zip metadata
+  when: __uc_ext_target_version | int < 0
+  block:
+    - name: gnome_extensions_install_one | Read version from zip when unknown (direct URL)
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - |
+            import zipfile, json, sys
+            z = zipfile.ZipFile(sys.argv[1])
+            m = json.load(z.open("metadata.json"))
+            v = m.get("version")
+            if v is None:
+                print("")
+            else:
+                print(str(v).strip())
+          - "{{ __uc_ext_local_bundle }}"
+      register: __user_config_ext_zip_version
+      changed_when: false
+      check_mode: false
+
+    - name: gnome_extensions_install_one | Apply version from zip metadata
+      when: __user_config_ext_zip_version.stdout | trim | regex_search('^[0-9]+$') is not none
+      ansible.builtin.set_fact:
+        __uc_ext_target_version: "{{ __user_config_ext_zip_version.stdout | trim | int }}"
+
+- name: gnome_extensions_install_one | Query installed extension
+  ansible.builtin.command:
+    cmd: gnome-extensions info "{{ __uc_ext_uuid }}"
+  register: __user_config_ext_info
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
+- name: gnome_extensions_install_one | Parse installed version from gnome-extensions info
+  ansible.builtin.set_fact:
+    __uc_ext_installed_version_raw: "{{ __user_config_ext_info.stdout | regex_findall('(?m)^Version:\\s*(\\d+)\\s*$') }}"
+
+- name: gnome_extensions_install_one | Stat on-disk extension metadata
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['user_dir'] }}/.local/share/gnome-shell/extensions/{{ __uc_ext_uuid }}/metadata.json"
+  register: __user_config_ext_metadata_stat
+
+# gnome-extensions list/info can lag behind the filesystem until GNOME Shell restarts; treat
+# metadata.json under ~/.local/share/gnome-shell/extensions/<uuid>/ as installed.
+- name: gnome_extensions_install_one | Set installed version from gnome-extensions info
+  when: __user_config_ext_info.rc == 0
+  ansible.builtin.set_fact:
+    __uc_ext_installed_version_int: >-
+      {{
+        (__uc_ext_installed_version_raw | first | int)
+        if (__uc_ext_installed_version_raw | length > 0) else -1
+      }}
+
+- name: gnome_extensions_install_one | Read on-disk metadata when session info is unavailable
+  when:
+    - __user_config_ext_info.rc != 0
+    - __user_config_ext_metadata_stat.stat.exists
+  block:
+    - name: gnome_extensions_install_one | Slurp on-disk metadata.json
+      ansible.builtin.slurp:
+        src: "{{ ansible_facts['user_dir'] }}/.local/share/gnome-shell/extensions/{{ __uc_ext_uuid }}/metadata.json"
+      register: __user_config_ext_metadata_slurp
+
+    - name: gnome_extensions_install_one | Set installed version from on-disk metadata
+      ansible.builtin.set_fact:
+        __uc_ext_installed_version_int: >-
+          {{
+            (
+              (__user_config_ext_metadata_slurp.content | b64decode | from_json).version
+              | default(-1, true) | int
+            )
+          }}
+
+- name: gnome_extensions_install_one | Set installed version when extension not present on disk
+  when:
+    - __user_config_ext_info.rc != 0
+    - not __user_config_ext_metadata_stat.stat.exists
+  ansible.builtin.set_fact:
+    __uc_ext_installed_version_int: -1
+
+- name: gnome_extensions_install_one | Detect whether extension is installed (session or on-disk)
+  ansible.builtin.set_fact:
+    __uc_ext_extension_present: >-
+      {{
+        (__user_config_ext_info.rc == 0)
+        or (__user_config_ext_metadata_stat.stat.exists | default(false))
+      }}
+
+- name: gnome_extensions_install_one | Decide if install or upgrade is needed
+  ansible.builtin.set_fact:
+    __uc_ext_need_install: >-
+      {{
+        __uc_ext_force
+        or (not __uc_ext_extension_present)
+        or (
+          (__uc_ext_target_version | int >= 0)
+          and (__uc_ext_installed_version_int | int >= 0)
+          and ((__uc_ext_target_version | int) > (__uc_ext_installed_version_int | int))
+        )
+      }}
+
+- name: gnome_extensions_install_one | Use force flag when reinstalling or upgrading
+  ansible.builtin.set_fact:
+    __uc_ext_use_f: >-
+      {{
+        __uc_ext_force
+        or (
+          (__uc_ext_target_version | int >= 0)
+          and (__uc_ext_installed_version_int | int >= 0)
+          and ((__uc_ext_target_version | int) > (__uc_ext_installed_version_int | int))
+        )
+      }}
+
+- name: gnome_extensions_install_one | Install or upgrade extension bundle
+  when: __uc_ext_need_install | bool
+  ansible.builtin.command:
+    argv: "{{ ['gnome-extensions', 'install'] + (['-f'] if __uc_ext_use_f | bool else []) + [__uc_ext_local_bundle] }}"
+  register: __user_config_ext_install
+  changed_when: __user_config_ext_install.rc == 0
+
+# org.gnome.shell enabled-extensions is updated once after all extensions are processed
+# (see gnome_extensions.yml) so dconf is read/written once and the list order is canonical.
+- name: gnome_extensions_install_one | Record UUID and enable flag for batch dconf update
+  ansible.builtin.set_fact:
+    __user_config_gnome_ext_enabled_plan: >-
+      {{
+        (__user_config_gnome_ext_enabled_plan | default([]))
+        + [{'uuid': __uc_ext_uuid, 'enable': __uc_ext_enable | bool}]
+      }}

--- a/roles/user_config/tasks/main.yml
+++ b/roles/user_config/tasks/main.yml
@@ -19,3 +19,8 @@
 - name: Include GTK tasks
   ansible.builtin.include_tasks:
     file: gtk.yml
+
+- name: Include GNOME Shell extension tasks
+  ansible.builtin.include_tasks:
+    file: gnome_extensions.yml
+  when: user_config_gnome_extensions | length > 0


### PR DESCRIPTION
Allows for installing GNOME extensions. Extensions are specified either as an ID, name, or URL to the zip file.

Example:

```
user_config_gnome_extensions:
  - name: "User Theme"
    url: "https://extensions.gnome.org/download-extension/user-theme@gnome-shell-extensions.gcampax.github.com.shell-extension.zip?version_tag=65086"
  - id: 615
  - name: Caffeine
    enable: false
```