### PR TITLE
Refactor dconf configuration to be dynamic

### DIFF
--- a/changelogs/fragments/user-config-dconf-variable.yml
+++ b/changelogs/fragments/user-config-dconf-variable.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - user_config role - replace hard-coded dconf tasks with the ``user_config_dconf_settings`` variable

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -30,6 +30,7 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | `user_config_slack_flatpak_filesystems` | Extra filesystem entries for the Slack override (list of strings); if empty, the `filesystems` line is omitted. |
 | `user_config_gtk_include_default_bookmarks` | If `true` (default), prepend GNOME-style XDG default bookmarks (`Documents`, `Downloads`, etc.) before `user_config_gtk_bookmarks`. Set `false` to manage only your explicit list. |
 | `user_config_gtk_bookmarks` | List of `path` (required) and optional `name` for GTK 3 `~/.config/gtk-3.0/bookmarks`. Paths may be `file://`, absolute, `~`, `~/`, or relative to the user home. |
+| `user_config_dconf_settings` | Dconf settings to apply. List of dicts with `key` (required), `value` (GVariant string, required when state is `present`), and optional `state` (`present` or `absent`, default `present`). |
 | `user_config_gnome_extensions` | GNOME Shell extensions to install. Each entry is a **dict** with at least one of `url` (direct HTTPS URL to the extension zip), `id` (extensions.gnome.org pk), or `name` (exact catalog name to search). Precedence is `url`, then `id`, then `name`. Optional `force` (pass `-f` to `gnome-extensions install`), optional `enable` (default `true`: `gnome-extensions enable`, or `disable` when `false`). Requires `gnome-extensions` and `gnome-shell` on the target. Bundles are downloaded to a **temporary directory** that is removed when extension tasks finish. |
 
 ## Dependencies

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -15,6 +15,10 @@ user_config_gtk_include_default_bookmarks: true
 # path: file:// URI, absolute path, ~ or ~/ (managed user's home), or path relative to that home.
 user_config_gtk_bookmarks: []
 
+# Dconf settings to apply. Each item: key (required), value (required unless state is absent), state (default present).
+# Values must be GVariant strings, e.g. "true", "false", "'hello'", "2".
+user_config_dconf_settings: []
+
 # GNOME Shell extensions (see README). Each item is a dict with at least one of id, name, url.
 # Resolution order: url (if set) else id (if set) else name. Optional: enable (default true), force.
 user_config_gnome_extensions: []

--- a/roles/user_config/meta/argument_specs.yml
+++ b/roles/user_config/meta/argument_specs.yml
@@ -48,6 +48,35 @@ argument_specs:
             required: false
             description: Optional display name for the bookmark.
 
+      user_config_dconf_settings:
+        type: list
+        elements: dict
+        required: false
+        default: []
+        description:
+          - Dconf settings to apply via community.general.dconf.
+          - Values must be GVariant strings (e.g. "true", "false", "'hello'", "2").
+        options:
+          key:
+            type: str
+            required: true
+            description:
+              - The dconf key path (e.g. /org/gnome/software/download-updates).
+          value:
+            type: str
+            required: false
+            description:
+              - The GVariant value to set. Required when state is present, omitted when state is absent.
+          state:
+            type: str
+            required: false
+            default: present
+            choices:
+              - present
+              - absent
+            description:
+              - Whether the key should be present or absent.
+
       user_config_gnome_extensions:
         type: list
         elements: dict

--- a/roles/user_config/tasks/dconf.yml
+++ b/roles/user_config/tasks/dconf.yml
@@ -1,18 +1,9 @@
 ---
-- name: Dconf | Disable Gnome Software update downloads
+- name: Dconf | Apply dconf settings
   community.general.dconf:
-    key: /org/gnome/software/download-updates
-    value: "false"
-    state: present
-
-- name: Dconf | Show battery percentage
-  community.general.dconf:
-    key: /org/gnome/desktop/interface/show-battery-percentage
-    value: "true"
-    state: present
-
-- name: Dconf | Disable auto maximizing windows
-  community.general.dconf:
-    key: /org/gnome/mutter/auto-maximize
-    value: "false"
-    state: present
+    key: "{{ item.key }}"
+    value: "{{ item.value | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+  loop: "{{ user_config_dconf_settings }}"
+  loop_control:
+    label: "{{ item.key }}"

--- a/roles/user_config/tasks/main.yml
+++ b/roles/user_config/tasks/main.yml
@@ -10,6 +10,7 @@
 - name: Include DConf tasks
   ansible.builtin.include_tasks:
     file: dconf.yml
+  when: user_config_dconf_settings | length > 0
 
 - name: Include Flatpak tasks
   ansible.builtin.include_tasks:


### PR DESCRIPTION
Don't hard-code dconf settings. Allow them to be set using a variable.