### PR TITLE
CI: workflow hardening, inline Galaxy release, RELEASING updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,32 @@ on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
 
+# One publish per tag; avoid overlapping runs if a release is re-triggered.
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   release_galaxy:
-    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@main
-    secrets: inherit
-    with:
-      environment: release
+    name: Galaxy release
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Build the collection
+        run: ansible-galaxy collection build -v --force
+      - name: Publish the collection on Galaxy
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANSIBLE_GALAXY_API_KEY}" ]; then
+            echo "ANSIBLE_GALAXY_API_KEY is required to publish to Galaxy"
+            exit 1
+          fi
+          TARBALL=$(ls -1 ./*.tar.gz)
+          ansible-galaxy collection publish "${TARBALL}" \
+            --api-key "${ANSIBLE_GALAXY_API_KEY}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 ---
 name: "CI"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -14,18 +17,18 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   changelog:
-    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@46de405af31ba872a770a9b75c90121493c1cbe5
     if: github.event_name == 'pull_request'
   build-import:
-    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@46de405af31ba872a770a9b75c90121493c1cbe5
   ansible-lint:
-    uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@46de405af31ba872a770a9b75c90121493c1cbe5
   sanity:
-    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@46de405af31ba872a770a9b75c90121493c1cbe5
   unit-galaxy:
-    uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@46de405af31ba872a770a9b75c90121493c1cbe5
   unit-source:
-    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
+    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2
     with:
       collection_pre_install: >-
         git+https://github.com/ansible-collections/ansible.utils.git

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,12 +27,12 @@ antsibull-changelog release
 This will:
 
 - Read all fragments from `changelogs/fragments/`
-- Generate/update `CHANGELOG.rst` and `changelogs/changelog.yaml`
+- Generate/update `CHANGELOG.rst`, `CHANGELOG.md`, and `changelogs/changelog.yaml`
 - Delete the processed fragment files (since `keep_fragments: false`)
 
 ## Step 4: Commit and push to `main`
 
-Commit all the changes (bumped `galaxy.yml`, updated `CHANGELOG.rst`,
+Commit all the changes (bumped `galaxy.yml`, updated changelog outputs,
 updated `changelogs/changelog.yaml`, deleted fragments) and merge to
 `main` via a PR.
 
@@ -43,7 +43,7 @@ On the repository's GitHub Releases page, create a new release:
 - **Tag:** Use the version number (e.g., `v1.1.0` or `1.1.0`)
 - **Target:** `main`
 - **Title:** e.g., `branic.system_management 1.1.0`
-- **Description:** Paste or reference the changelog entry
+- **Description:** Use the notes for this version from `CHANGELOG.md` (or `CHANGELOG.rst`). You can **paste** that section into the release body so subscribers see full text in the release UI and emails, or **link** to the file at the tag you are creating, for example `https://github.com/branic/system_management/blob/v1.1.0/CHANGELOG.md` (use your real tag and version). You can also do both: a short summary plus a link to the full changelog.
 - **Publish** the release (do not leave it as a draft)
 
 ## Step 6: Verify
@@ -54,8 +54,22 @@ GitHub to confirm the workflow succeeded.
 
 ## Prerequisites
 
-- A GitHub Environment named `release` must be configured on the
-  repository with the appropriate secrets (e.g., `ANSIBLE_GALAXY_API_KEY`).
+- Configure a GitHub Environment named **`release`**. The `release.yml` workflow
+  assigns that environment to the Galaxy publish job so **deployment protection
+  rules apply** and **environment secrets** (including the Galaxy API token) are
+  available to the job.
+- Add the **Ansible Galaxy API token** under **Settings → Environments →
+  `release` → Environment secrets** using the name **`ANSIBLE_GALAXY_API_KEY`**
+  (same name the workflow reads). Create or copy the token from Ansible Galaxy
+  (profile / token management on [galaxy.ansible.com](https://galaxy.ansible.com)).
+  GitHub treats secret names as **case-insensitive**; the UI may show the name in
+  uppercase.
+- Under **Settings → Environments → `release` → Deployment protection rules**,
+  **Deployment branches and tags** must allow the Git tags used for releases.
+  For semver tags like `v1.0.0`, add a tag pattern such as `v*.*.*` (or a
+  narrower pattern you prefer). If only certain branches are allowed, the
+  release workflow fails immediately with an environment protection error when
+  a release is published from a tag.
 - `antsibull-changelog` must be installed locally to compile fragments
   before release. CI only validates fragments; it does not auto-generate
   the changelog.


### PR DESCRIPTION
## Summary

This PR updates GitHub Actions and release documentation:

- **Security / maintenance:** Pin third-party reusable workflows to commit SHAs, add `permissions: contents: read`, add Dependabot for GitHub Actions, and add release concurrency (one publish per tag without cancelling in-flight runs).
- **Galaxy release:** Replace the external `release_galaxy` reusable workflow with an **inline** job that sets `environment: release`, so the Ansible Galaxy API token can remain an **environment secret** (`ANSIBLE_GALAXY_API_KEY`).
- **Docs:** Align `RELEASING.md` prerequisites with the above (environment, tag protection, token location).

## Testing

- [ ] CI passes on this PR
- [ ] After merge, confirm a release workflow run can publish to Galaxy (or dry-run locally with `ansible-galaxy collection build`)

Made with [Cursor](https://cursor.com)