### PR TITLE
feat(openshift_local): optional CRC version pin and GitHub uri fixes

### DIFF
--- a/changelogs/fragments/openshift-local-crc-version-pin.yml
+++ b/changelogs/fragments/openshift-local-crc-version-pin.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - openshift_local - add optional ``openshift_local_crc_version`` to pin a CRC release (validated before download).

--- a/roles/openshift_local/README.md
+++ b/roles/openshift_local/README.md
@@ -2,7 +2,7 @@
 
 Installs or upgrades **OpenShift Local** (the `crc` CLI) for the **user that runs this role** (the SSH connection user, or **`become_user`** when the role runs with privilege escalation).
 
-The role compares the **GitHub** latest release tag with the installed `crc version`, downloads the matching **Linux** archive from the **Red Hat mirror** when the binary is missing or outdated, reconciles **`crc` configuration** from a single dictionary variable, runs **`crc delete --force`** (non-interactive) and **`crc setup`** when anything needs to change, optionally removes **stale** `.crcbundle` files under the cache path reported by `crc setup`, and can maintain **bash completion** in `~/.bashrc`.
+The role resolves a **target** CRC version from **GitHub** (either the newest release or a **pinned** `openshift_local_crc_version`), compares it with the installed `crc version`, downloads the matching **Linux** archive from the **Red Hat mirror** under `.../clients/crc/<semver>/` when the binary is missing or outdated, reconciles **`crc` configuration** from a single dictionary variable, runs **`crc delete --force`** (non-interactive) and **`crc setup`** when anything needs to change, optionally removes **stale** `.crcbundle` files under the cache path reported by `crc setup`, and can maintain **bash completion** in `~/.bashrc`.
 
 See [Configuring CRC](https://crc.dev/docs/configuring/) for upstream property names and semantics.
 
@@ -20,9 +20,14 @@ See [Configuring CRC](https://crc.dev/docs/configuring/) for upstream property n
 - The role runs **`ansible.builtin.setup`** with subsets **`!all`**, **`min`**, **`hardware`**, and **`virtual`** so host CPU, memory, and disk checks work and **`ansible_facts['user_dir']`** matches the effective user (including **`become_user`**).
 - **`openshift_local_bin_dir`** defaults to **`~/.local/bin`**. Set it to install the binary elsewhere.
 
+## CRC version selection
+
+- **`openshift_local_crc_version`** (default **empty**): When **empty** or unset, the role uses the **newest** CRC release returned by GitHub's releases API. When set to **`X.Y.Z`** or **`vX.Y.Z`** (digits only in each segment), the role installs that release only. The value is **validated** with a strict pattern before any GitHub or mirror URL is built; invalid values fail immediately with a clear message. A version that does not exist on GitHub causes the **`releases/tags/...`** request to fail (for example HTTP 404).
+- The **`crc` Linux tarball** is fetched from the Red Hat mirror at **`.../openshift-v4/clients/crc/<semver>/crc-linux-<arch>.tar.xz`**, where **`<semver>`** matches the GitHub tag (without a leading **`v`**). If a tag is very new, the mirror may lag GitHub briefly; in that case **`ansible.builtin.unarchive`** can fail until the artifact is published.
+
 ## Host prerequisites and resources
 
-- **Fedora / RHEL family:** The role always checks the required RPM list in [`vars/main.yml`](vars/main.yml). If **`openshift_local_install_host_packages`** is `true`, it runs **`dnf`** with **`state: present`** (idempotent, so already-installed packages are left alone). It then **refreshes package facts** and **asserts** every required package is present—so verification always reflects the system after any install, and the install path cannot pass while facts still show missing packages.
+- **Fedora / RHEL family:** The role always checks the required RPM list in [`vars/main.yml`](vars/main.yml). If **`openshift_local_install_host_packages`** is `true`, it runs **`dnf`** with **`state: present`** (idempotent, so already-installed packages are left alone). It then **refreshes package facts** and **asserts** every required package is present, so verification always reflects the system after any install, and the install path cannot pass while facts still show missing packages.
 - **Other OS families:** Package tasks are skipped (optional debug at verbosity 1).
 - **All targets:** The role **fails** if the host does not meet **preset-based** CPU, RAM, and free disk minimums (see [`vars/main.yml`](vars/main.yml) and [CRC system requirements](https://crc.dev/docs/using/)). The effective preset defaults to **`openshift`** when **`openshift_local_crc_config.preset`** is unset.
 - If **`openshift_local_crc_config`** sets **`cpus`**, **`memory`**, or **`disk-size`**, those values must be **greater than or equal to** the CRC-documented minimums for the selected preset (same tables in [`vars/main.yml`](vars/main.yml)). Free space on the filesystem that contains **`user_dir`** (from **`df`**) must be at least the **maximum** of the preset's host disk minimum and any configured **`disk-size`** (GiB).
@@ -37,7 +42,7 @@ See [Configuring CRC](https://crc.dev/docs/configuring/) for upstream property n
 
 The role performs a full reconcile when **any** of the following is true:
 
-- The **`crc`** binary is missing, or its version does not match the latest tag from GitHub.
+- The **`crc`** binary is missing, or its version does not match the **target** version from GitHub.
 - Any key in the effective desired config **differs** from the live configuration.
 
 When reconcile is required, the role:
@@ -58,6 +63,7 @@ See [`defaults/main.yml`](defaults/main.yml) and [`meta/argument_specs.yml`](met
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `openshift_local_bin_dir` | No | `~/.local/bin` | Directory for the `crc` binary. |
+| `openshift_local_crc_version` | No | `""` | Pin CRC to `X.Y.Z` or `vX.Y.Z`, or leave empty for newest GitHub release (validated before URLs are built). |
 | `openshift_local_crc_config` | No | `{}` | Dict of desired `crc config` keys and values. |
 | `openshift_local_install_host_packages` | No | `false` | When `false`, only verify required host packages are installed. When `true`, install them if needed (requires privilege escalation). Only Fedora/RHEL supported. |
 | `openshift_local_crc_setup_temporary_sudo` | No | `true` | When `true`, before **`crc setup`** the role writes a validated temporary **`sudoers.d`** file granting the connection user passwordless **`sudo`**, then deletes it afterward. Requires privilege escalation for those tasks. Use `false` if passwordless **`sudo`** is already configured. |
@@ -74,6 +80,7 @@ See [`defaults/main.yml`](defaults/main.yml) and [`meta/argument_specs.yml`](met
   roles:
     - role: branic.system_management.openshift_local
       vars:
+        openshift_local_crc_version: "2.58.0"
         openshift_local_crc_config:
           preset: openshift
           cpus: 4

--- a/roles/openshift_local/defaults/main.yml
+++ b/roles/openshift_local/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 openshift_local_manage_bashrc_completion: true
 
+# When empty, install the newest CRC release from GitHub. When set (e.g. "2.58.0" or "v2.58.0"),
+# install that release only. Must match X.Y.Z or vX.Y.Z (see role validation).
+openshift_local_crc_version: ""
+
 # Desired crc config keys and values (see https://crc.dev/docs/configuring/). Empty means the
 # role does not enforce crc settings beyond internal preset default used for validation.
 openshift_local_crc_config: {}

--- a/roles/openshift_local/meta/argument_specs.yml
+++ b/roles/openshift_local/meta/argument_specs.yml
@@ -4,11 +4,11 @@ argument_specs:
     short_description: Install or upgrade OpenShift Local (CRC) for the connection user
     description:
       - >-
-        Installs or upgrades the crc CLI from the Red Hat mirror, reconciles crc configuration
-        from openshift_local_crc_config, runs crc delete --force and crc setup when the binary or
-        configuration drifts, checks Fedora/RHEL host packages (optional install), validates host
-        resources and sizing keys against preset minimums, optionally prunes stale bundle caches,
-        and can maintain bash completion in ~/.bashrc.
+        Installs or upgrades the crc CLI from the Red Hat mirror (specific semver or latest from
+        GitHub), reconciles crc configuration from openshift_local_crc_config, runs crc delete
+        --force and crc setup when the binary or configuration drifts, checks Fedora/RHEL host
+        packages (optional install), validates host resources and sizing keys against preset
+        minimums, optionally prunes stale bundle caches, and can maintain bash completion in ~/.bashrc.
     author:
       - Brant Evans
     options:
@@ -26,6 +26,19 @@ argument_specs:
         description:
           - Directory for the crc binary (must be on PATH for interactive use).
           - If unset, the role sets this after gathering facts to ansible_facts user_dir plus /.local/bin.
+
+      openshift_local_crc_version:
+        type: str
+        required: false
+        default: ""
+        description:
+          - >-
+            CRC release to install, as X.Y.Z or vX.Y.Z (digits only; used in GitHub and mirror URLs).
+            When empty or unset, the role uses the newest release from GitHub. Invalid values fail
+            before any HTTP request. A pinned release that does not exist on GitHub fails that request.
+          - >-
+            The Linux archive is downloaded from the Red Hat mirror under
+            openshift-v4/clients/crc/<semver>/.
 
       openshift_local_crc_config:
         type: dict

--- a/roles/openshift_local/tasks/host_prereqs.yml
+++ b/roles/openshift_local/tasks/host_prereqs.yml
@@ -26,6 +26,7 @@
         fail_msg: >-
           Required package '{{ item }}' is not installed. Install it manually, or set
           openshift_local_install_host_packages to true so the role can install it (requires privilege escalation).
+        quiet: true
       loop: "{{ __openshift_local_host_packages }}"
       loop_control:
         label: "{{ item }}"

--- a/roles/openshift_local/tasks/install_upgrade.yml
+++ b/roles/openshift_local/tasks/install_upgrade.yml
@@ -4,7 +4,7 @@
     (not __openshift_local_crc_cli_stat.stat.exists)
     or (
       __openshift_local_installed_crc_version | default('')
-      != __openshift_local_latest_crc_version
+      != __openshift_local_target_crc_version
     )
   ansible.builtin.unarchive:
     src: >-

--- a/roles/openshift_local/tasks/main.yml
+++ b/roles/openshift_local/tasks/main.yml
@@ -52,25 +52,77 @@
   ansible.builtin.include_tasks:
     file: verify_resources.yml
 
-- name: Retrieve latest CRC release metadata from GitHub
+- name: Resolve openshift_local_crc_version input for pin handling
+  ansible.builtin.set_fact:
+    __openshift_local_crc_version_input: "{{ openshift_local_crc_version | default('', true) | trim }}"
+
+- name: Validate pinned CRC semver format
+  when: __openshift_local_crc_version_input | length > 0
+  ansible.builtin.assert:
+    that:
+      - __openshift_local_crc_version_input is match('^v?[0-9]+\.[0-9]+\.[0-9]+$')
+    fail_msg: >-
+      openshift_local_crc_version must match X.Y.Z or vX.Y.Z (digits only in each segment). This
+      value is used in GitHub and Red Hat mirror URL path segments. Received:
+      {{ __openshift_local_crc_version_input }}
+    quiet: true
+
+- name: Retrieve pinned CRC release metadata from GitHub
+  when: __openshift_local_crc_version_input | length > 0
   ansible.builtin.uri:
-    url: "{{ __openshift_local_crc_github_releases_api }}"
+    url: >-
+      {{ __openshift_local_crc_github_api_base ~ '/releases/tags/v' ~
+      (__openshift_local_crc_version_input | regex_replace('^v', '')) }}
     headers:
       Accept: application/vnd.github+json
     return_content: false
     status_code:
       - 200
-  register: __openshift_local_crc_latest_release
+  register: __openshift_local_crc_gh_pinned
   check_mode: false
-  failed_when: (__openshift_local_crc_latest_release.json | default([]) | length) < 1
 
-- name: Determine latest CRC version from GitHub tag
+- name: Retrieve latest CRC release metadata from GitHub
+  when: __openshift_local_crc_version_input | length == 0
+  ansible.builtin.uri:
+    url: "{{ __openshift_local_crc_github_releases_latest }}"
+    headers:
+      Accept: application/vnd.github+json
+    return_content: false
+    status_code:
+      - 200
+  register: __openshift_local_crc_gh_latest
+  check_mode: false
+  failed_when: (__openshift_local_crc_gh_latest['json'] | default([]) | length) < 1
+
+- name: Select active GitHub releases API uri result
   ansible.builtin.set_fact:
-    __openshift_local_latest_crc_version: >-
+    __openshift_local_crc_gh_uri: >-
       {{
-        __openshift_local_crc_latest_release.json[0]['tag_name']
+        __openshift_local_crc_gh_pinned
+        if (__openshift_local_crc_version_input | length > 0)
+        else __openshift_local_crc_gh_latest
+      }}
+
+- name: Set GitHub API JSON payload from uri result
+  ansible.builtin.set_fact:
+    __openshift_local_crc_gh_body: "{{ __openshift_local_crc_gh_uri['json'] }}"
+
+- name: Determine target CRC version from GitHub tag
+  ansible.builtin.set_fact:
+    __openshift_local_target_crc_version: >-
+      {{
+        (
+          __openshift_local_crc_gh_body['tag_name']
+          if __openshift_local_crc_gh_body is mapping
+          else __openshift_local_crc_gh_body[0]['tag_name']
+        )
         | regex_replace('^v((?:\d+\.?){1,3})$', '\1')
       }}
+
+- name: Set Red Hat mirror base for crc-linux archive download
+  ansible.builtin.set_fact:
+    __openshift_local_crc_download_base: >-
+      {{ __openshift_local_crc_clients_crc_root ~ '/' ~ __openshift_local_target_crc_version }}
 
 - name: Check if crc binary is present
   ansible.builtin.stat:
@@ -105,7 +157,7 @@
         (not __openshift_local_crc_cli_stat.stat.exists)
         or (
           __openshift_local_installed_crc_version | default('')
-          != __openshift_local_latest_crc_version
+          != __openshift_local_target_crc_version
         )
         or (
           (__openshift_local_crc_config_keys_to_apply | default([]) | length) > 0
@@ -117,7 +169,7 @@
     msg:
       - >-
         Installed Version: {{ __openshift_local_installed_crc_version | default('NOT INSTALLED') }}
-      - "Latest Version:    {{ __openshift_local_latest_crc_version }}"
+      - "Target Version:    {{ __openshift_local_target_crc_version }}"
       - "Reconcile required: {{ __openshift_local_needs_reconcile }}"
       - >-
         CRC config keys to apply: {{ __openshift_local_crc_config_keys_to_apply | default([]) | length }}

--- a/roles/openshift_local/tasks/verify_resources.yml
+++ b/roles/openshift_local/tasks/verify_resources.yml
@@ -56,6 +56,7 @@
     fail_msg: >-
       Host has {{ ansible_facts['processor_vcpus'] | default(ansible_facts['ansible_processor_vcpus'], true) }} vCPU(s);
       preset '{{ __openshift_local_effective_preset }}' requires at least {{ __openshift_local_preset_mins['host_cpus'] }}.
+    quiet: true
 
 - name: verify_resources | Assert host memory meets preset minimum
   ansible.builtin.assert:
@@ -64,6 +65,7 @@
     fail_msg: >-
       Host has {{ ansible_facts['memtotal_mb'] }} MiB RAM; preset '{{ __openshift_local_effective_preset }}'
       requires at least {{ __openshift_local_preset_mins['host_memory_mb'] }} MiB.
+    quiet: true
 
 - name: verify_resources | Assert free disk on home filesystem meets preset and disk-size needs
   ansible.builtin.assert:
@@ -76,6 +78,7 @@
       {{ __openshift_local_preset_mins['host_disk_free_gb'] }} GiB (preset '{{ __openshift_local_effective_preset }}'
       documentation minimum){% if 'disk-size' in openshift_local_crc_config %} and
       {{ openshift_local_crc_config['disk-size'] | int }} GiB (configured crc disk-size){% endif %}.
+    quiet: true
 
 - name: verify_resources | Validate desired cpus against CRC minimum for preset
   when: "'cpus' in openshift_local_crc_config"
@@ -85,6 +88,7 @@
     fail_msg: >-
       openshift_local_crc_config.cpus ({{ openshift_local_crc_config['cpus'] }}) is below the minimum
       {{ __openshift_local_preset_mins['crc_cpus'] }} for preset '{{ __openshift_local_effective_preset }}'.
+    quiet: true
 
 - name: verify_resources | Validate desired memory against CRC minimum for preset
   when: "'memory' in openshift_local_crc_config"
@@ -94,6 +98,7 @@
     fail_msg: >-
       openshift_local_crc_config.memory ({{ openshift_local_crc_config['memory'] }} MiB) is below the minimum
       {{ __openshift_local_preset_mins['crc_memory_mib'] }} MiB for preset '{{ __openshift_local_effective_preset }}'.
+    quiet: true
 
 - name: verify_resources | Validate desired disk-size meets CRC minimum for preset
   when: "'disk-size' in openshift_local_crc_config"
@@ -103,3 +108,4 @@
     fail_msg: >-
       openshift_local_crc_config['disk-size'] ({{ openshift_local_crc_config['disk-size'] }} GiB) is below the minimum
       {{ __openshift_local_preset_mins['crc_disk_size_gib'] }} GiB for preset '{{ __openshift_local_effective_preset }}'.
+    quiet: true

--- a/roles/openshift_local/vars/main.yml
+++ b/roles/openshift_local/vars/main.yml
@@ -1,10 +1,13 @@
 ---
-# Internal: GitHub Releases API (first page item = newest by publish date).
-__openshift_local_crc_github_releases_api: https://api.github.com/repos/crc-org/crc/releases?per_page=1
+# Internal: GitHub API base for crc-org/crc (releases list and release-by-tag).
+__openshift_local_crc_github_api_base: https://api.github.com/repos/crc-org/crc
 
-# Internal: Red Hat mirror base; archive name is crc-linux-<arch>.tar.xz under "latest".
-__openshift_local_crc_download_base: >-
-  https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest
+# Internal: GitHub Releases API (first page item = newest by publish date).
+__openshift_local_crc_github_releases_latest: "{{ __openshift_local_crc_github_api_base }}/releases?per_page=1"
+
+# Internal: Red Hat mirror directory root per CRC semver; archive is crc-linux-<arch>.tar.xz below it.
+__openshift_local_crc_clients_crc_root: >-
+  https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc
 
 # Internal: RPM names checked (and optionally installed) on Fedora/RHEL family hosts.
 __openshift_local_host_packages:


### PR DESCRIPTION
## Summary

Adds optional `openshift_local_crc_version` so installs can pin a CRC release (`X.Y.Z` or `vX.Y.Z`) with validation before any GitHub or mirror URL is built. Unpinned behavior still follows the newest GitHub release.

## Details

- Resolve metadata from GitHub via release-by-tag when pinned, or `releases?per_page=1` when unpinned.
- Download the Linux archive from the Red Hat mirror under `.../clients/crc/<semver>/` (no `/latest` path).
- Use separate `uri` registers and coalesce them so a skipped second task does not corrupt the registered response (fixes `dict has no attribute json` / empty `json` on Ansible 2.20).
- README and `argument_specs` updated; assert tasks use `quiet: true` where applicable.
- Changelog fragment: `changelogs/fragments/openshift-local-crc-version-pin.yml`.

## Testing

- `ansible-lint` (production profile) on `roles/openshift_local`.

Made with [Cursor](https://cursor.com)