### PR TITLE
chore: quiet assert tasks in multiple roles

### DIFF
--- a/changelogs/fragments/role-assert-quiet.yml
+++ b/changelogs/fragments/role-assert-quiet.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - install_cloud_clis, secureboot_signing, user_config — set ``quiet: true`` on ``assert`` tasks.

--- a/roles/install_cloud_clis/tasks/helm.yml
+++ b/roles/install_cloud_clis/tasks/helm.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_helm_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA helm release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: helm | Determine latest helm version
   ansible.builtin.set_fact:

--- a/roles/install_cloud_clis/tasks/kube-linter.yml
+++ b/roles/install_cloud_clis/tasks/kube-linter.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_kube_linter_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA kube-linter release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: kube-linter | Determine latest kube-linter version
   ansible.builtin.set_fact:

--- a/roles/install_cloud_clis/tasks/kustomize.yml
+++ b/roles/install_cloud_clis/tasks/kustomize.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_kustomize_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA kustomize release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: kustomize | Determine latest kustomize version
   ansible.builtin.set_fact:

--- a/roles/install_cloud_clis/tasks/rosa_cli.yml
+++ b/roles/install_cloud_clis/tasks/rosa_cli.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_rosa_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA ROSA CLI release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: rosa_cli | Determine latest ROSA CLI version
   ansible.builtin.set_fact:

--- a/roles/install_cloud_clis/tasks/stern.yml
+++ b/roles/install_cloud_clis/tasks/stern.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_stern_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA stern release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: stern | Determine latest stern version
   ansible.builtin.set_fact:

--- a/roles/install_cloud_clis/tasks/tekton_cli.yml
+++ b/roles/install_cloud_clis/tasks/tekton_cli.yml
@@ -37,6 +37,7 @@
       - __install_cloud_clis_latest_tekton_cli_ver_details['tag_name'] is defined
     fail_msg: >-
       Could not resolve a GA Tekton CLI release for the highest semver (check API response and tag format).
+    quiet: true
 
 - name: tekton_cli | Determine latest Tekton CLI version
   ansible.builtin.set_fact:

--- a/roles/secureboot_signing/tasks/main.yml
+++ b/roles/secureboot_signing/tasks/main.yml
@@ -24,6 +24,7 @@
         fail_msg: >-
           secureboot_signing_mok_password must be between 8 and 16 characters.
           This password is entered at the UEFI MOK Manager screen during enrollment.
+        quiet: true
 
     - name: Secure Boot | Install prerequisites
       ansible.builtin.dnf5:

--- a/roles/user_config/tasks/gnome_extensions.yml
+++ b/roles/user_config/tasks/gnome_extensions.yml
@@ -36,6 +36,7 @@
     fail_msg: >-
       Could not determine GNOME Shell version. Ensure gnome-shell is installed and
       `gnome-shell --version` prints a version number (e.g. GNOME Shell 49.4).
+    quiet: true
 
 - name: gnome_extensions | Create temporary directory for extension bundles
   ansible.builtin.tempfile:

--- a/roles/user_config/tasks/gnome_extensions_ego_by_name.yml
+++ b/roles/user_config/tasks/gnome_extensions_ego_by_name.yml
@@ -29,6 +29,7 @@
     fail_msg: >-
       No extension on extensions.gnome.org has the exact name
       "{{ __user_config_gnome_ext_item.name | trim }}".
+    quiet: true
 
 - name: gnome_extensions_ego_by_name | Set EGO primary key from name search
   ansible.builtin.set_fact:

--- a/roles/user_config/tasks/gnome_extensions_install_one.yml
+++ b/roles/user_config/tasks/gnome_extensions_install_one.yml
@@ -6,6 +6,7 @@
     that:
       - __user_config_gnome_ext_item is mapping
     fail_msg: user_config_gnome_extensions entries must be dictionaries (id, name, and/or url).
+    quiet: true
 
 - name: gnome_extensions_install_one | Detect which keys are set
   ansible.builtin.set_fact:
@@ -31,6 +32,7 @@
     that:
       - (__uc_ext_has_url | bool) or (__uc_ext_has_id | bool) or (__uc_ext_has_name | bool)
     fail_msg: Each extension entry needs at least one of url, id, or name.
+    quiet: true
 
 - name: gnome_extensions_install_one | Common options
   ansible.builtin.set_fact:
@@ -77,12 +79,14 @@
     that:
       - ( __uc_ext_ego_json | default({}) ).download_url | default('') | string | length > 0
     fail_msg: extensions.gnome.org did not return a download_url for this GNOME Shell version.
+    quiet: true
 
 - name: gnome_extensions_install_one | Require resolved download URL
   ansible.builtin.assert:
     that:
       - __uc_ext_full_download_url | default('') | length > 0
     fail_msg: Could not determine extension download URL.
+    quiet: true
 
 - name: gnome_extensions_install_one | Set local bundle path
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary

Adds `quiet: true` to `ansible.builtin.assert` tasks so successful runs do not print the default "All assertions passed" noise.

## Roles

- `install_cloud_clis` (helm, kustomize, kube-linter, rosa_cli, stern, tekton_cli)
- `secureboot_signing`
- `user_config` (GNOME extension install paths)

## Changelog

- `changelogs/fragments/role-assert-quiet.yml` (trivial)

Made with [Cursor](https://cursor.com)