### PR TITLE
feat(system_config): dnf swap package replacements

### DIFF
--- a/changelogs/fragments/system-config-package-replacements.yml
+++ b/changelogs/fragments/system-config-package-replacements.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    system_config role — add ``system_config_package_replacements`` for ``dnf swap``
+    pairs (optional ``allowerasing``), running after repo setup and before DNF package install.

--- a/roles/system_config/README.md
+++ b/roles/system_config/README.md
@@ -5,6 +5,7 @@ System-wide configuration for **Fedora Linux**-style hosts:
 - **RPM Fusion** repository enablement (free, nonfree, or both)
 - **DNF repositories** and **COPR repositories**
 - **DNF packages** (installed via `dnf5`)
+- optional **RPM replacements** (`dnf swap`), for example `ffmpeg-free` → `ffmpeg`, or `libva-intel-media-driver` → `intel-media-driver` when both names exist in DNF
 - local **groups** and **users**
 - **Flatpak**
   - **Flathub** remote
@@ -26,6 +27,7 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | `system_config_dnf_repositories` | List of DNF repository definitions: `name` and `description` (required); optional `baseurl`, `metalink`, `gpgcheck`, `gpgkey`, `repo_gpgcheck`, `enabled`, `state`. |
 | `system_config_copr_repositories` | List of COPR repository definitions: `name` in `owner/project` format (required); optional `state` (`enabled` / `disabled` / `absent`). |
 | `system_config_packages` | List of package names to install via DNF. |
+| `system_config_package_replacements` | Optional list of `dnf swap` pairs: `remove` and `install` (required); optional `allowerasing` (default false). Runs after repos are configured and before `system_config_packages`; skipped when `remove` is not installed. DNF only needs to resolve `install`—same as any package install, regardless of which repository provides it. |
 | `system_config_flatpak_packages` | List of Flatpak application IDs to install |
 | `system_config_groups` | Optional list of group definitions: `name` (required), optional `gid`, `system`. |
 | `system_config_users` | Optional list of user definitions: `name` (required); optional `uid`, `comment`, `groups`, `shell`, `system`, `create_home`, `password`, `update_password` (`on_create` / `always`). |
@@ -65,6 +67,11 @@ With variables:
             gpgkey: https://example.com/RPM-GPG-KEY-example
         system_config_copr_repositories:
           - name: user/project
+        system_config_package_replacements:
+          - remove: ffmpeg-free
+            install: ffmpeg
+          - remove: libva-intel-media-driver
+            install: intel-media-driver
         system_config_packages:
           - vim-enhanced
           - htop
@@ -82,7 +89,7 @@ With variables:
 
 ## Idempotency and check mode
 
-Repository, package, group, user, and Flatpak remote tasks are intended to be idempotent. DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
+Repository, package, group, user, and Flatpak remote tasks are intended to be idempotent. RPM replacement tasks use `dnf swap` via `ansible.builtin.command` when the package being removed is installed; they are skipped in Ansible check mode (same as other `command` tasks without `creates`/`removes`). DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
 
 ## License
 

--- a/roles/system_config/defaults/main.yml
+++ b/roles/system_config/defaults/main.yml
@@ -40,6 +40,17 @@ system_config_copr_repositories: []
 
 system_config_packages: []
 
+# Replace conflicting distro packages in one transaction (runs before system_config_packages).
+# DNF must resolve the install package name (configure repos here or elsewhere like any install).
+# system_config_package_replacements:
+#   - remove: libva-intel-media-driver
+#     install: intel-media-driver
+#   - remove: ffmpeg-free
+#     install: ffmpeg
+#     # allowerasing: true
+
+system_config_package_replacements: []
+
 # system_config_v4l2loopback: true
 system_config_v4l2loopback: false
 system_config_v4l2loopback_devices: 1

--- a/roles/system_config/meta/argument_specs.yml
+++ b/roles/system_config/meta/argument_specs.yml
@@ -99,6 +99,29 @@ argument_specs:
         description:
           - "A list of packages to install via DNF."
           - "The full list is passed to dnf5 in a single transaction."
+      system_config_package_replacements:
+        type: "list"
+        elements: "dict"
+        required: false
+        description:
+          - "Pairs of packages to exchange using C(dnf swap), before C(system_config_packages) runs."
+          - "Each swap removes C(remove) and installs C(install) in one transaction."
+          - "Swaps run only when C(remove) is currently installed (idempotent)."
+          - "The C(install) name must be visible to DNF when the task runs (same as installing any package—use this role's repo variables or repos already on the host)."
+        options:
+          remove:
+            type: "str"
+            required: true
+            description: "Installed package name to remove."
+          install:
+            type: "str"
+            required: true
+            description: "Replacement package name to install."
+          allowerasing:
+            type: "bool"
+            required: false
+            default: false
+            description: "Pass C(--allowerasing) to C(dnf) when dependency resolution requires erasing packages."
       system_config_v4l2loopback:
         type: "bool"
         required: false

--- a/roles/system_config/tasks/packages.yml
+++ b/roles/system_config/tasks/packages.yml
@@ -22,6 +22,35 @@
     name: "{{ item.name }}"
     state: "{{ item.state | default('enabled') }}"
 
+- name: Packages | Refresh installed package facts for RPM replacements
+  when: (system_config_package_replacements | default([])) | length > 0
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Packages | Replace conflicting RPMs via dnf swap
+  when:
+    - (system_config_package_replacements | default([])) | length > 0
+    - item.remove in ansible_facts.packages
+  ansible.builtin.command:
+    cmd: >-
+      /usr/bin/dnf{%- if item.allowerasing | default(false) %} --allowerasing{% endif %}
+       swap --assumeyes {{ item.remove }} {{ item.install }}
+  loop: "{{ system_config_package_replacements | default([]) }}"
+  loop_control:
+    label: "{{ item.remove }} -> {{ item.install }}"
+  register: __system_config_package_replacement
+  changed_when: >-
+    (
+      'Installing' in ((__system_config_package_replacement.stdout | default(''))
+        ~ (__system_config_package_replacement.stderr | default('')))
+      or 'Removing' in ((__system_config_package_replacement.stdout | default(''))
+        ~ (__system_config_package_replacement.stderr | default('')))
+      or 'Upgrading' in ((__system_config_package_replacement.stdout | default(''))
+        ~ (__system_config_package_replacement.stderr | default('')))
+      or 'Downgrading' in ((__system_config_package_replacement.stdout | default(''))
+        ~ (__system_config_package_replacement.stderr | default('')))
+    )
+
 - name: Packages | Install DNF packages
   when: (system_config_packages | default([])) | length > 0
   ansible.builtin.dnf5:


### PR DESCRIPTION
## Summary

Adds `system_config_package_replacements` to the `system_config` role: declarative `dnf swap` pairs (`remove` / `install`) with optional `allowerasing`, after repo/COPR setup and before `system_config_packages`.

## Details

- Runs `package_facts` when the list is non-empty; swaps only when `remove` is installed (idempotent).
- Uses `ansible.builtin.command` because `ansible.builtin.dnf5` does not implement swap.
- Documented in README, `argument_specs.yml`, defaults comments; changelog fragment included.

## Example

```yaml
system_config_package_replacements:
  - remove: ffmpeg-free
    install: ffmpeg
  - remove: libva-intel-media-driver
    install: intel-media-driver
```

Made with [Cursor](https://cursor.com)