### PR TITLE
feat(system_config): sysctl variables and ansible.posix dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ PEP440 is the schema used to describe the versions of Ansible.
 
 Some modules and plugins require external libraries. Please check the requirements for each plugin or module you use in the documentation to find out which requirements are needed.
 
-When you install this collection with Ansible Galaxy, declared dependencies are installed as well. This collection depends on **`community.general` >=8.0.0** (see `galaxy.yml`).
+When you install this collection with Ansible Galaxy, declared dependencies are installed as well. This collection depends on **`ansible.posix` >=1.5.0** and **`community.general` >=8.0.0** (see `galaxy.yml`).
 
 ## Included content
 

--- a/changelogs/fragments/system-config-sysctl.yml
+++ b/changelogs/fragments/system-config-sysctl.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - system_config role — add sysctl configuration support.
+  - Add ``ansible.posix`` collection dependency.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,6 +14,7 @@ description: Fedora Linux system configuration and management
 license_file: LICENSE
 tags: ["linux", "tools", "fedora"]
 dependencies:
+  "ansible.posix": ">=1.5.0"
   "community.general": ">=8.0.0"
 
 repository: https://github.com/branic/system_management

--- a/roles/system_config/README.md
+++ b/roles/system_config/README.md
@@ -6,6 +6,7 @@ System-wide configuration for **Fedora Linux**-style hosts:
 - **DNF repositories** and **COPR repositories**
 - **DNF packages** (installed via `dnf5`)
 - optional **RPM replacements** (`dnf swap`), for example `ffmpeg-free` → `ffmpeg`, or `libva-intel-media-driver` → `intel-media-driver` when both names exist in DNF
+- optional **`sysctl`** parameters via `ansible.posix.sysctl`, persisted under `/etc/sysctl.d/` by default
 - local **groups** and **users**
 - **Flatpak**
   - **Flathub** remote
@@ -15,6 +16,7 @@ System-wide configuration for **Fedora Linux**-style hosts:
 
 - Ansible **2.16+** (see `meta/main.yml`).
 - Collections:
+  - **ansible.posix** (provides `ansible.posix.sysctl`)
   - **community.general**
 
 ## Role variables
@@ -28,6 +30,8 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | `system_config_copr_repositories` | List of COPR repository definitions: `name` in `owner/project` format (required); optional `state` (`enabled` / `disabled` / `absent`). |
 | `system_config_packages` | List of package names to install via DNF. |
 | `system_config_package_replacements` | Optional list of `dnf swap` pairs: `remove` and `install` (required); optional `allowerasing` (default false). Runs after repos are configured and before `system_config_packages`; skipped when `remove` is not installed. DNF only needs to resolve `install`—same as any package install, regardless of which repository provides it. |
+| `system_config_sysctl_file` | Default sysctl drop-in path for entries that do not set `sysctl_file` (default `/etc/sysctl.d/99-system_config.conf`). |
+| `system_config_sysctl` | Optional list of sysctl definitions: `name` (required); `value` (required when `state` is `present`); optional `state` (`present` / `absent`), `sysctl_file`, `reload` (default true). Runs after package/repo tasks and before Flatpak. |
 | `system_config_flatpak_packages` | List of Flatpak application IDs to install |
 | `system_config_groups` | Optional list of group definitions: `name` (required), optional `gid`, `system`. |
 | `system_config_users` | Optional list of user definitions: `name` (required); optional `uid`, `comment`, `groups`, `shell`, `system`, `create_home`, `password`, `update_password` (`on_create` / `always`). |
@@ -76,6 +80,9 @@ With variables:
           - vim-enhanced
           - htop
           - tmux
+        system_config_sysctl:
+          - name: vm.swappiness
+            value: "10"
         system_config_flatpak_packages:
           - org.videolan.VLC
         system_config_groups:
@@ -89,7 +96,7 @@ With variables:
 
 ## Idempotency and check mode
 
-Repository, package, group, user, and Flatpak remote tasks are intended to be idempotent. RPM replacement tasks use `dnf swap` via `ansible.builtin.command` when the package being removed is installed; they are skipped in Ansible check mode (same as other `command` tasks without `creates`/`removes`). DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
+Repository, package, sysctl, group, user, and Flatpak remote tasks are intended to be idempotent. RPM replacement tasks use `dnf swap` via `ansible.builtin.command` when the package being removed is installed; they are skipped in Ansible check mode (same as other `command` tasks without `creates`/`removes`). DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
 
 ## License
 

--- a/roles/system_config/defaults/main.yml
+++ b/roles/system_config/defaults/main.yml
@@ -51,6 +51,13 @@ system_config_packages: []
 
 system_config_package_replacements: []
 
+# system_config_sysctl:
+#   - name: vm.swappiness
+#     value: "10"
+# Persisted under system_config_sysctl_file (default /etc/sysctl.d/99-system_config.conf).
+system_config_sysctl: []
+system_config_sysctl_file: /etc/sysctl.d/99-system_config.conf
+
 # system_config_v4l2loopback: true
 system_config_v4l2loopback: false
 system_config_v4l2loopback_devices: 1

--- a/roles/system_config/meta/argument_specs.yml
+++ b/roles/system_config/meta/argument_specs.yml
@@ -236,3 +236,47 @@ argument_specs:
               - "on_create"
               - "always"
             description: "When to update the users password."
+      system_config_sysctl_file:
+        type: "str"
+        required: false
+        default: "/etc/sysctl.d/99-system_config.conf"
+        description:
+          - "Path to the sysctl drop-in file used when an entry does not set C(sysctl_file)."
+          - "Typically under C(/etc/sysctl.d/) so settings persist across reboots."
+      system_config_sysctl:
+        type: "list"
+        elements: "dict"
+        required: false
+        description:
+          - "Sysctl parameters to manage via C(ansible.posix.sysctl)."
+          - "Entries are written to C(system_config_sysctl_file) unless overridden per entry."
+        options:
+          name:
+            type: "str"
+            required: true
+            description: "Sysctl parameter name (for example C(vm.swappiness))."
+          value:
+            type: "raw"
+            required: false
+            description:
+              - "Value to set when C(state) is C(present)."
+              - "Required when C(state) is C(present)."
+          state:
+            type: "str"
+            required: false
+            default: "present"
+            choices:
+              - "present"
+              - "absent"
+            description: "Whether the parameter should be set in the sysctl file or removed."
+          sysctl_file:
+            type: "str"
+            required: false
+            description:
+              - "Override C(system_config_sysctl_file) for this entry only."
+          reload:
+            type: "bool"
+            required: false
+            default: true
+            description:
+              - "Whether to reload sysctl immediately (C(sysctl -p)) after changing the file."

--- a/roles/system_config/tasks/main.yml
+++ b/roles/system_config/tasks/main.yml
@@ -20,6 +20,11 @@
   ansible.builtin.include_tasks:
     file: packages.yml
 
+- name: Include sysctl tasks
+  when: (system_config_sysctl | default([])) | length > 0
+  ansible.builtin.include_tasks:
+    file: sysctl.yml
+
 - name: Include Flatpak tasks
   ansible.builtin.include_tasks:
     file: flatpak.yml

--- a/roles/system_config/tasks/sysctl.yml
+++ b/roles/system_config/tasks/sysctl.yml
@@ -1,0 +1,11 @@
+---
+- name: Sysctl | Ensure sysctl parameters
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    sysctl_file: "{{ item.sysctl_file | default(system_config_sysctl_file) }}"
+    reload: "{{ item.reload | default(true) }}"
+  loop: "{{ system_config_sysctl }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
## Summary

- Add `system_config_sysctl` and `system_config_sysctl_file` to the `system_config` role for managing sysctl entries with `ansible.posix.sysctl`.
- Default sysctl drop-in path is `/etc/sysctl.d/99-system_config.conf`; tasks run after package/repo setup and before Flatpak when the list is non-empty.
- Declare `ansible.posix` >=1.5.0 in `galaxy.yml` and document the dependency in collection and role README files.
- Add changelog fragment.

Made with [Cursor](https://cursor.com)