### PR TITLE
docs(roles): normalize galaxy meta and argument_specs version_added

### DIFF
--- a/changelogs/fragments/role-meta-version-added.yml
+++ b/changelogs/fragments/role-meta-version-added.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Normalize role ``meta/main.yml``; ``version_added: 1.0.0`` on argument specs.

--- a/plugins/filter/gnome_clocks.py
+++ b/plugins/filter/gnome_clocks.py
@@ -21,7 +21,7 @@ __metaclass__ = type  # pylint: disable=C0103
 DOCUMENTATION = """
     name: to_gnome_clocks
     author: Brant Evans
-    version_added: "1.1.0"
+    version_added: "1.0.0"
     short_description: Convert a list of locations to a GNOME world-clocks GVariant string.
     description:
       - Accepts a list of location dictionaries and produces the GVariant string

--- a/roles/install_cloud_clis/meta/argument_specs.yml
+++ b/roles/install_cloud_clis/meta/argument_specs.yml
@@ -6,6 +6,7 @@ argument_specs:
       - Installs or updates CLIs under install_cloud_clis_bin_dir (defaults at runtime to ~/.local/bin under ansible_facts user_dir after the role gathers facts).
     author:
       - Brant Evans
+    version_added: "1.0.0"
     options:
       install_cloud_clis_components:
         type: list

--- a/roles/install_cloud_clis/meta/main.yml
+++ b/roles/install_cloud_clis/meta/main.yml
@@ -1,35 +1,9 @@
 ---
 galaxy_info:
   author: Brant Evans
-  description: Installs and updates various cloud CLIs
-  # company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
+  description: Install and update cloud and Kubernetes CLIs for the connection user.
   license: GPL-3.0-only
-
   min_ansible_version: "2.16"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/openshift_local/meta/argument_specs.yml
+++ b/roles/openshift_local/meta/argument_specs.yml
@@ -11,6 +11,7 @@ argument_specs:
         minimums, optionally prunes stale bundle caches, and can maintain bash completion in ~/.bashrc.
     author:
       - Brant Evans
+    version_added: "1.0.0"
     options:
       openshift_local_manage_bashrc_completion:
         type: bool

--- a/roles/openshift_local/meta/main.yml
+++ b/roles/openshift_local/meta/main.yml
@@ -1,35 +1,9 @@
 ---
 galaxy_info:
   author: Brant Evans
-  description: Installs and upgrades OpenShift Local (CRC) for the connection user
-  # company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
+  description: Install or upgrade OpenShift Local (CRC) for the connection user.
   license: GPL-3.0-only
-
   min_ansible_version: "2.16"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/secureboot_signing/meta/argument_specs.yml
+++ b/roles/secureboot_signing/meta/argument_specs.yml
@@ -10,6 +10,7 @@ argument_specs:
         MOK enrollment in the UEFI MOK Manager screen.
     author:
       - Brant Evans
+    version_added: "1.0.0"
     options:
       secureboot_signing_mok_password:
         type: "str"

--- a/roles/secureboot_signing/meta/main.yml
+++ b/roles/secureboot_signing/meta/main.yml
@@ -1,35 +1,9 @@
 ---
 galaxy_info:
   author: Brant Evans
-  description: Configures Secure Boot MOK enrollment and kernel module signing for akmods and dkms
-  # company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
+  description: Secure Boot MOK enrollment and kernel module signing (akmods, dkms).
   license: GPL-3.0-only
-
   min_ansible_version: "2.16"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/system_config/meta/argument_specs.yml
+++ b/roles/system_config/meta/argument_specs.yml
@@ -6,6 +6,7 @@ argument_specs:
       - This role configures a Fedora Linux system.
     author:
       - Brant Evans
+    version_added: "1.0.0"
     options:
       system_config_rpmfusion:
         type: "str"

--- a/roles/system_config/meta/main.yml
+++ b/roles/system_config/meta/main.yml
@@ -1,35 +1,9 @@
 ---
 galaxy_info:
   author: Brant Evans
-  description: System wide configuration
-  # company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
+  description: Fedora Linux system-wide configuration (repos, packages, users, Flatpak).
   license: GPL-3.0-only
-
   min_ansible_version: "2.16"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/user_config/meta/argument_specs.yml
+++ b/roles/user_config/meta/argument_specs.yml
@@ -6,6 +6,7 @@ argument_specs:
       - Configures the Ansible connection user's environment preferences.
     author:
       - Brant Evans
+    version_added: "1.0.0"
     options:
       user_config_slack_flatpak_sockets:
         type: bool

--- a/roles/user_config/meta/main.yml
+++ b/roles/user_config/meta/main.yml
@@ -1,35 +1,9 @@
 ---
 galaxy_info:
   author: Brant Evans
-  description: Configure user based settings
-  # company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
+  description: Per-user configuration preferences for the Ansible connection user.
   license: GPL-3.0-only
-
   min_ansible_version: "2.16"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.


### PR DESCRIPTION
## Summary

- Slim, consistent `meta/main.yml` across all five roles (aligned descriptions).
- Set `version_added: "1.0.0"` on each role's `argument_specs.main` entrypoint.
- Concise changelog fragment.

Made with [Cursor](https://cursor.com)