### PR TITLE
feat(roles): systemd units for system_config and user_config

### DIFF
--- a/changelogs/fragments/role-assert-quiet.yml
+++ b/changelogs/fragments/role-assert-quiet.yml
@@ -1,3 +1,4 @@
 ---
 trivial:
-  - install_cloud_clis, secureboot_signing, user_config — set ``quiet: true`` on ``assert`` tasks.
+  - >-
+    install_cloud_clis, secureboot_signing, user_config — set ``quiet: true`` on ``assert`` tasks.

--- a/changelogs/fragments/role-meta-version-added.yml
+++ b/changelogs/fragments/role-meta-version-added.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - Normalize role ``meta/main.yml``; ``version_added: 1.0.0`` on argument specs.
+  - >-
+    Normalize role ``meta/main.yml``; ``version_added: 1.0.0`` on argument specs.

--- a/changelogs/fragments/roles-systemd-units.yml
+++ b/changelogs/fragments/roles-systemd-units.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - system_config and user_config roles can manage systemd units (system and user scope).

--- a/roles/system_config/README.md
+++ b/roles/system_config/README.md
@@ -7,6 +7,7 @@ System-wide configuration for **Fedora Linux**-style hosts:
 - **DNF packages** (installed via `dnf5`)
 - optional **RPM replacements** (`dnf swap`), for example `ffmpeg-free` → `ffmpeg`, or `libva-intel-media-driver` → `intel-media-driver` when both names exist in DNF
 - optional **`sysctl`** parameters via `ansible.posix.sysctl`, persisted under `/etc/sysctl.d/` by default
+- optional **systemd units** (system scope) via `ansible.builtin.systemd_service`
 - local **groups** and **users**
 - **Flatpak**
   - **Flathub** remote
@@ -32,6 +33,7 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | `system_config_package_replacements` | Optional list of `dnf swap` pairs: `remove` and `install` (required); optional `allowerasing` (default false). Runs after repos are configured and before `system_config_packages`; skipped when `remove` is not installed. DNF only needs to resolve `install`—same as any package install, regardless of which repository provides it. |
 | `system_config_sysctl_file` | Default sysctl drop-in path for entries that do not set `sysctl_file` (default `/etc/sysctl.d/99-system_config.conf`). |
 | `system_config_sysctl` | Optional list of sysctl definitions: `name` (required); `value` (required when `state` is `present`); optional `state` (`present` / `absent`), `sysctl_file`, `reload` (default true). Runs after package/repo tasks and before Flatpak. |
+| `system_config_systemd_units` | Optional list of systemd units (system manager): `name` (required); at least one of `enabled` or `state` per entry; optional `masked`, `daemon_reload` (default false). `state` values: `started`, `stopped`, `restarted`, `reloaded`. Runs after sysctl and before Flatpak. |
 | `system_config_flatpak_packages` | List of Flatpak application IDs to install |
 | `system_config_groups` | Optional list of group definitions: `name` (required), optional `gid`, `system`. |
 | `system_config_users` | Optional list of user definitions: `name` (required); optional `uid`, `comment`, `groups`, `shell`, `system`, `create_home`, `password`, `update_password` (`on_create` / `always`). |
@@ -83,6 +85,10 @@ With variables:
         system_config_sysctl:
           - name: vm.swappiness
             value: "10"
+        system_config_systemd_units:
+          - name: nginx.service
+            enabled: true
+            state: started
         system_config_flatpak_packages:
           - org.videolan.VLC
         system_config_groups:
@@ -96,7 +102,7 @@ With variables:
 
 ## Idempotency and check mode
 
-Repository, package, sysctl, group, user, and Flatpak remote tasks are intended to be idempotent. RPM replacement tasks use `dnf swap` via `ansible.builtin.command` when the package being removed is installed; they are skipped in Ansible check mode (same as other `command` tasks without `creates`/`removes`). DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
+Repository, package, sysctl, systemd, group, user, and Flatpak remote tasks are intended to be idempotent. RPM replacement tasks use `dnf swap` via `ansible.builtin.command` when the package being removed is installed; they are skipped in Ansible check mode (same as other `command` tasks without `creates`/`removes`). DNF package installs use `state: present`; Flatpak installs use `state: latest` -- review whether that matches your change expectations.
 
 ## License
 

--- a/roles/system_config/defaults/main.yml
+++ b/roles/system_config/defaults/main.yml
@@ -58,6 +58,14 @@ system_config_package_replacements: []
 system_config_sysctl: []
 system_config_sysctl_file: /etc/sysctl.d/99-system_config.conf
 
+# systemd units (system scope). Each item: name (required); at least one of enabled or state;
+# optional masked, daemon_reload (default false). Example:
+# system_config_systemd_units:
+#   - name: nginx.service
+#     enabled: true
+#     state: started
+system_config_systemd_units: []
+
 # system_config_v4l2loopback: true
 system_config_v4l2loopback: false
 system_config_v4l2loopback_devices: 1

--- a/roles/system_config/meta/argument_specs.yml
+++ b/roles/system_config/meta/argument_specs.yml
@@ -281,3 +281,43 @@ argument_specs:
             default: true
             description:
               - "Whether to reload sysctl immediately (C(sysctl -p)) after changing the file."
+      system_config_systemd_units:
+        type: "list"
+        elements: "dict"
+        required: false
+        description:
+          - "Systemd units to manage in the system scope (C(systemctl), default scope)."
+          - "Each entry must set C(name). At least one of C(enabled) or C(state) is required per entry."
+          - "Runs after sysctl tasks and before Flatpak."
+        options:
+          name:
+            type: "str"
+            required: true
+            description: "Unit name (for example C(nginx.service) or C(sshd.socket))."
+          enabled:
+            type: "bool"
+            required: false
+            description:
+              - "Whether the unit should start on boot (enable/disable)."
+              - "Omit when only managing C(state) or C(masked)."
+          state:
+            type: "str"
+            required: false
+            choices:
+              - "started"
+              - "stopped"
+              - "restarted"
+              - "reloaded"
+            description:
+              - "Active unit state."
+              - "Use C(started) with C(enabled) true for C(systemctl enable --now) behavior."
+          masked:
+            type: "bool"
+            required: false
+            description: "Whether the unit should be masked."
+          daemon_reload:
+            type: "bool"
+            required: false
+            default: false
+            description:
+              - "Run C(systemctl daemon-reload) before other operations for this unit."

--- a/roles/system_config/tasks/main.yml
+++ b/roles/system_config/tasks/main.yml
@@ -25,6 +25,11 @@
   ansible.builtin.include_tasks:
     file: sysctl.yml
 
+- name: Include systemd unit tasks
+  when: (system_config_systemd_units | default([])) | length > 0
+  ansible.builtin.include_tasks:
+    file: systemd_units.yml
+
 - name: Include Flatpak tasks
   ansible.builtin.include_tasks:
     file: flatpak.yml

--- a/roles/system_config/tasks/systemd_units.yml
+++ b/roles/system_config/tasks/systemd_units.yml
@@ -1,0 +1,11 @@
+---
+- name: Systemd | Ensure system units
+  ansible.builtin.systemd_service:
+    daemon_reload: "{{ item.daemon_reload | default(false) }}"
+    enabled: "{{ item.enabled | default(omit) }}"
+    masked: "{{ item.masked | default(omit) }}"
+    name: "{{ item.name }}"
+    state: "{{ item.state | default(omit) }}"
+  loop: "{{ system_config_systemd_units }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -9,6 +9,7 @@ Configure per-user desktop settings for the **user that runs this role** (the SS
 - [uv](https://docs.astral.sh/uv/) Python package manager (standalone installer)
 - Python tool installation via uv
 - VS Code and Cursor editor extensions (via `code` / `cursor` CLI)
+- optional **user systemd units** (`systemctl --user`) via `ansible.builtin.systemd_service`
 
 ## Requirements
 
@@ -24,6 +25,7 @@ Configure per-user desktop settings for the **user that runs this role** (the SS
 - The role **always** runs **`setup`** with a minimal subset (`!all` + `min`) as its first task so **`ansible_facts['user_dir']`** matches the **effective** user for the role (including **`become_user`**). That avoids stale `user_dir` values from an earlier play-level `gather_facts` that ran as the SSH user while the role runs as someone else.
 - Paths use **`ansible_facts['user_dir']`**. File **`owner`** / **`group`** use **`ansible_facts['user_id']`** and **`ansible_facts['user_gid']`** (same minimal `setup` as `user_dir`), so ownership matches the **effective** user (including **`become_user`**), not the SSH connection user.
 - Using **`become_user`** (for example connect as `ansible`, become `brant`) is supported for targeting that user's home. Arbitrary `become` to root while configuring another account without **`become_user`** is still not what this role assumes.
+- **User systemd** (`user_config_systemd_units`) needs the effective user's D-Bus user session and `XDG_RUNTIME_DIR` (normal graphical or SSH login, or **logind lingering**). Headless runs without a session often fail with errors such as “Failed to connect to bus”.
 
 ## Role variables
 
@@ -45,6 +47,7 @@ See `defaults/main.yml` and `meta/argument_specs.yml` for the full specification
 | `user_config_cursor_extensions` | Cursor extensions (same string format as VS Code). Uses the `cursor` CLI. Skipped when empty. |
 | `user_config_vscode_cli` | Optional full path to the `code` binary; when empty, `command -v code` is used. |
 | `user_config_cursor_cli` | Optional full path to the `cursor` binary; when empty, `command -v cursor` is used. |
+| `user_config_systemd_units` | Optional list of systemd units for the **user** manager: `name` (required); at least one of `enabled` or `state` per entry; optional `masked`, `daemon_reload` (default false). `state`: `started`, `stopped`, `restarted`, `reloaded`. Use `enabled: true` and `state: started` for `systemctl --user enable --now` behavior (for example `keyboxd.socket`). |
 
 ## Dependencies
 
@@ -77,6 +80,10 @@ With variables:
         user_config_slack_flatpak_sockets: true
         user_config_vscode_extensions:
           - redhat.ansible
+        user_config_systemd_units:
+          - name: keyboxd.socket
+            enabled: true
+            state: started
 ```
 
 ## Idempotency and check mode

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -25,7 +25,7 @@ Configure per-user desktop settings for the **user that runs this role** (the SS
 - The role **always** runs **`setup`** with a minimal subset (`!all` + `min`) as its first task so **`ansible_facts['user_dir']`** matches the **effective** user for the role (including **`become_user`**). That avoids stale `user_dir` values from an earlier play-level `gather_facts` that ran as the SSH user while the role runs as someone else.
 - Paths use **`ansible_facts['user_dir']`**. File **`owner`** / **`group`** use **`ansible_facts['user_id']`** and **`ansible_facts['user_gid']`** (same minimal `setup` as `user_dir`), so ownership matches the **effective** user (including **`become_user`**), not the SSH connection user.
 - Using **`become_user`** (for example connect as `ansible`, become `brant`) is supported for targeting that user's home. Arbitrary `become` to root while configuring another account without **`become_user`** is still not what this role assumes.
-- **User systemd** (`user_config_systemd_units`) needs the effective user's D-Bus user session and `XDG_RUNTIME_DIR` (normal graphical or SSH login, or **logind lingering**). Headless runs without a session often fail with errors such as “Failed to connect to bus”.
+- **User systemd** (`user_config_systemd_units`) needs the effective user's D-Bus user session and `XDG_RUNTIME_DIR` (normal graphical or SSH login, or **logind lingering**). Headless runs without a session often fail with errors such as "Failed to connect to bus".
 
 ## Role variables
 

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -46,3 +46,12 @@ user_config_vscode_cli: ""
 
 # Full path to the Cursor `cursor` binary; empty uses `command -v cursor`.
 user_config_cursor_cli: ""
+
+# systemd units (user scope / systemctl --user). Each item: name (required); at least one of enabled or state;
+# optional masked, daemon_reload (default false). Requires user dbus and XDG_RUNTIME_DIR (login session or lingering).
+# Example:
+# user_config_systemd_units:
+#   - name: keyboxd.socket
+#     enabled: true
+#     state: started
+user_config_systemd_units: []

--- a/roles/user_config/meta/argument_specs.yml
+++ b/roles/user_config/meta/argument_specs.yml
@@ -181,3 +181,45 @@ argument_specs:
         default: ""
         description:
           - Path to the cursor executable. When empty, the role uses command -v cursor.
+
+      user_config_systemd_units:
+        type: list
+        elements: dict
+        required: false
+        description:
+          - Systemd units to manage in the user scope (C(systemctl --user)).
+          - Each entry must set name. At least one of enabled or state is required per entry.
+          - Requires a user D-Bus session and XDG_RUNTIME_DIR (interactive login or logind lingering); otherwise systemctl --user may fail.
+        options:
+          name:
+            type: str
+            required: true
+            description:
+              - Unit name (for example keyboxd.socket).
+          enabled:
+            type: bool
+            required: false
+            description:
+              - Whether the unit should start on boot for the user (enable/disable).
+              - Omit when only managing state or masked.
+          state:
+            type: str
+            required: false
+            choices:
+              - started
+              - stopped
+              - restarted
+              - reloaded
+            description:
+              - Active unit state for the user manager.
+              - Use started with enabled true for systemctl enable --now behavior.
+          masked:
+            type: bool
+            required: false
+            description: Whether the unit should be masked for the user.
+          daemon_reload:
+            type: bool
+            required: false
+            default: false
+            description:
+              - Run systemctl daemon-reload before other operations for this unit (user scope).

--- a/roles/user_config/tasks/main.yml
+++ b/roles/user_config/tasks/main.yml
@@ -21,6 +21,11 @@
   ansible.builtin.include_tasks:
     file: flatpak.yml
 
+- name: Include systemd user unit tasks
+  when: (user_config_systemd_units | default([])) | length > 0
+  ansible.builtin.include_tasks:
+    file: systemd_units.yml
+
 - name: Include GTK tasks
   ansible.builtin.include_tasks:
     file: gtk.yml

--- a/roles/user_config/tasks/systemd_units.yml
+++ b/roles/user_config/tasks/systemd_units.yml
@@ -1,0 +1,12 @@
+---
+- name: Systemd | Ensure user units
+  ansible.builtin.systemd_service:
+    daemon_reload: "{{ item.daemon_reload | default(false) }}"
+    enabled: "{{ item.enabled | default(omit) }}"
+    masked: "{{ item.masked | default(omit) }}"
+    name: "{{ item.name }}"
+    scope: user
+    state: "{{ item.state | default(omit) }}"
+  loop: "{{ user_config_systemd_units }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
## Summary

- Add `system_config_systemd_units` (system manager) and `user_config_systemd_units` (`systemctl --user`), documented in role READMEs and `argument_specs`.
- New task files loop `ansible.builtin.systemd_service`; user role sets `scope: user`.

## Changelog

`changelogs/fragments/roles-systemd-units.yml` (minor).

Made with [Cursor](https://cursor.com)