### PR TITLE
fix(install_cloud_clis): ROSA mirror probe and resilient CLI installs

### DIFF
--- a/changelogs/fragments/install-cloud-clis-rosa-mirror-probe.yml
+++ b/changelogs/fragments/install-cloud-clis-rosa-mirror-probe.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - install_cloud_clis role - resolve ROSA CLI install version from mirror.openshift.com
+    availability so a GitHub release ahead of the mirror does not fail the play
+minor_changes:
+  - install_cloud_clis role - isolate each CLI install in block/rescue so one component
+    failure does not block remaining installs
+  - install_cloud_clis role - loop CLI installs from install_cloud_clis_cli_installers
+    to reduce duplicated task definitions in main.yml

--- a/roles/install_cloud_clis/README.md
+++ b/roles/install_cloud_clis/README.md
@@ -21,7 +21,7 @@ Binaries are placed under **`install_cloud_clis_bin_dir`**. If you do not set it
   - **GitHub** (`api.github.com`, `github.com`) — version checks and release assets for most CLIs (including gws, stern, Tekton, kube-linter, kustomize, OCM, and Helm version discovery)
   - **AWS** (`awscli.amazonaws.com`) — AWS CLI installer (tags resolved via GitHub)
   - **Helm** (`get.helm.sh`) — Helm binary download
-  - **OpenShift mirrors** (`mirror.openshift.com`) — oc and rosa CLI binaries (ROSA version also uses GitHub)
+  - **OpenShift mirrors** (`mirror.openshift.com`) — oc and rosa CLI binaries (ROSA semver candidates from GitHub; installable version is the newest GA release present on the mirror)
 - Targets are **x86_64 Linux** (download URLs and archives are fixed for that architecture).
 
 ## Facts and connection
@@ -44,6 +44,11 @@ See [`defaults/main.yml`](defaults/main.yml) (component list) and [`meta/argumen
 ## Dependencies
 
 The **collection** declares a dependency on **`community.general`** (see the collection [`galaxy.yml`](../../galaxy.yml)); Tekton CLI tasks use **`community.general.version_sort`** to pick the highest semantic version among GitHub GA releases.
+
+### ROSA CLI
+
+- **Candidate versions** come from **non-prerelease** GitHub releases (`openshift/rosa`). The role installs the **newest GA version that is already published** on `mirror.openshift.com/pub/cgw/rosa` (probing the ten newest GitHub versions). When GitHub is ahead of the mirror, the play continues and a message notes the lag.
+- A failure in one CLI component (network, mirror, or install error) is **recorded and skipped**; other components in `install_cloud_clis_components` still run.
 
 ### Tekton CLI (`tkn`)
 
@@ -82,7 +87,7 @@ When `install_cloud_clis_manage_bashrc_completion` is `true`, the role writes on
 
 `# BEGIN ANSIBLE MANAGED BLOCK branic.system_management.install_cloud_clis` and `# END ANSIBLE MANAGED BLOCK branic.system_management.install_cloud_clis`
 
-The block uses **`if command -v …; then` / `fi`** stanzas and `# shellcheck source=/dev/null` before `source <(…)` completions, matching common interactive shell style. Only CLIs listed in `install_cloud_clis_components` are included, in the same order as installs in this role (`main.yml`).
+The block uses **`if command -v …; then` / `fi`** stanzas and `# shellcheck source=/dev/null` before `source <(…)` completions, matching common interactive shell style. Only CLIs listed in `install_cloud_clis_components` are included, in the same order as `install_cloud_clis_cli_installers` in [`vars/main.yml`](vars/main.yml).
 
 `blockinfile` runs with **`backup: true`** (timestamped `.bashrc` backup beside the file) and sets **`mode: 0644`** on `.bashrc` when the module updates the file. Add your own completions **outside** that marked region (for example in `~/.bashrc-local` or after the block) so the role does not manage them.
 

--- a/roles/install_cloud_clis/tasks/install_cli_component.yml
+++ b/roles/install_cloud_clis/tasks/install_cli_component.yml
@@ -1,0 +1,12 @@
+---
+- name: Install CLI component block
+  block:
+    - name: Run CLI install tasks
+      ansible.builtin.include_tasks:
+        file: "{{ install_cloud_clis_cli.tasks_file }}"
+  rescue:
+    - name: Record skipped CLI install
+      ansible.builtin.set_fact:
+        install_cloud_clis_update_messages: >
+          {{ install_cloud_clis_update_messages
+             + [install_cloud_clis_cli.label + ": skipped (" + (ansible_failed_result.msg | default('unknown error')) + ")"] }}

--- a/roles/install_cloud_clis/tasks/main.yml
+++ b/roles/install_cloud_clis/tasks/main.yml
@@ -18,55 +18,13 @@
 
 - name: Update CLIs (Block)
   block:
-    - name: Install AWS CLI
-      when: "'aws' in install_cloud_clis_components"
+    - name: Install CLI components
       ansible.builtin.include_tasks:
-        file: aws_cli.yml
-
-    - name: Install OC CLI
-      when: "'oc' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: oc_cli.yml
-
-    - name: Install OCM CLI
-      when: "'ocm' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: ocm_cli.yml
-
-    - name: Install ROSA CLI
-      when: "'rosa' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: rosa_cli.yml
-
-    - name: Install Tekton CLI
-      when: "'tekton' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: tekton_cli.yml
-
-    - name: Install kube-linter
-      when: "'kube_linter' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: kube-linter.yml
-
-    - name: Install kustomize
-      when: "'kustomize' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: kustomize.yml
-
-    - name: Install stern
-      when: "'stern' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: stern.yml
-
-    - name: Install helm
-      when: "'helm' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: helm.yml
-
-    - name: Install Google Workspace CLI
-      when: "'gws' in install_cloud_clis_components"
-      ansible.builtin.include_tasks:
-        file: gws_cli.yml
+        file: install_cli_component.yml
+      loop: "{{ install_cloud_clis_cli_installers | selectattr('component', 'in', install_cloud_clis_components) | list }}"
+      loop_control:
+        loop_var: install_cloud_clis_cli
+        label: "{{ install_cloud_clis_cli.label }}"
 
   always:
     - name: Refresh .bashrc completion block

--- a/roles/install_cloud_clis/tasks/rosa_cli.yml
+++ b/roles/install_cloud_clis/tasks/rosa_cli.yml
@@ -13,9 +13,17 @@
          | selectattr('tag_name', 'match', '^v([0-9.]+)$')
          | list }}
 
-- name: rosa_cli | Determine highest semver among GA releases
+- name: rosa_cli | Assert at least one GA ROSA CLI release was returned from GitHub
+  ansible.builtin.assert:
+    that:
+      - __install_cloud_clis_rosa_ga_releases | length > 0
+    fail_msg: >-
+      Could not resolve any GA ROSA CLI releases from GitHub (check API response and tag format).
+    quiet: true
+
+- name: rosa_cli | Determine highest semver among GA releases (GitHub)
   ansible.builtin.set_fact:
-    __install_cloud_clis_rosa_highest_semver: >-
+    __install_cloud_clis_rosa_github_highest_semver: >-
       {{ (__install_cloud_clis_rosa_ga_releases
          | map(attribute='tag_name')
          | map('regex_replace', '^v', '')
@@ -23,28 +31,47 @@
          | community.general.version_sort
          | last) }}
 
-- name: rosa_cli | Determine latest ROSA GA release details
+- name: rosa_cli | Build GA release versions sorted newest first
   ansible.builtin.set_fact:
-    __install_cloud_clis_latest_rosa_cli_ver_details: >-
-      {{ __install_cloud_clis_rosa_ga_releases
-         | selectattr('tag_name', 'equalto', 'v' ~ __install_cloud_clis_rosa_highest_semver)
-         | first }}
+    __install_cloud_clis_rosa_ga_versions_sorted: >-
+      {{ (__install_cloud_clis_rosa_ga_releases
+         | map(attribute='tag_name')
+         | map('regex_replace', '^v', '')
+         | list
+         | community.general.version_sort
+         | reverse
+         | list) }}
 
-- name: rosa_cli | Assert a matching GA ROSA CLI release was resolved
-  ansible.builtin.assert:
-    that:
-      - __install_cloud_clis_latest_rosa_cli_ver_details is defined
-      - __install_cloud_clis_latest_rosa_cli_ver_details['tag_name'] is defined
-    fail_msg: >-
-      Could not resolve a GA ROSA CLI release for the highest semver (check API response and tag format).
-    quiet: true
+- name: rosa_cli | Probe mirror for available ROSA CLI versions
+  ansible.builtin.uri:
+    url: "https://mirror.openshift.com/pub/cgw/rosa/{{ item }}/rosa-linux.tar.gz"
+    method: HEAD
+    status_code: [200, 404]
+  loop: "{{ __install_cloud_clis_rosa_ga_versions_sorted[:10] }}"
+  register: __install_cloud_clis_rosa_mirror_probe
 
-- name: rosa_cli | Determine latest ROSA CLI version
+- name: rosa_cli | Determine latest mirror-available ROSA CLI version
   ansible.builtin.set_fact:
     __install_cloud_clis_latest_rosa_cli_ver: >-
-      {{ __install_cloud_clis_latest_rosa_cli_ver_details['tag_name'] |
-         regex_replace('^v(?P<version>[0-9.]+)$', '\g<version>')
-      }}
+      {{ (__install_cloud_clis_rosa_mirror_probe.results
+         | selectattr('status', 'equalto', 200)
+         | map(attribute='item')
+         | first) | default('', true) }}
+
+- name: rosa_cli | Assert a mirror-available ROSA CLI version was resolved
+  ansible.builtin.assert:
+    that:
+      - __install_cloud_clis_latest_rosa_cli_ver | length > 0
+    fail_msg: >-
+      Could not find any GA ROSA CLI release on mirror.openshift.com (checked the 10 newest GitHub GA versions).
+    quiet: true
+
+- name: rosa_cli | Warn when GitHub latest exceeds mirror availability
+  when: __install_cloud_clis_rosa_github_highest_semver != __install_cloud_clis_latest_rosa_cli_ver
+  ansible.builtin.debug:
+    msg: >-
+      ROSA CLI {{ __install_cloud_clis_rosa_github_highest_semver }} is on GitHub but not yet on
+      mirror.openshift.com; using {{ __install_cloud_clis_latest_rosa_cli_ver }}.
 
 - name: rosa_cli | Check if ROSA CLI binary installed
   ansible.builtin.stat:
@@ -74,6 +101,7 @@
       [
         "Installed Version: {{ __install_cloud_clis_installed_rosa_cli_ver | default('NOT INSTALLED') }}",
         "Latest Version:    {{ __install_cloud_clis_latest_rosa_cli_ver | default('UNKNOWN') }}",
+        "GitHub Latest:     {{ __install_cloud_clis_rosa_github_highest_semver | default('UNKNOWN') }}",
       ]
     verbosity: 1
 

--- a/roles/install_cloud_clis/vars/main.yml
+++ b/roles/install_cloud_clis/vars/main.yml
@@ -2,3 +2,36 @@
 # vars file for install_cloud_clis
 
 install_cloud_clis_update_messages: []
+
+# Install order: used by main.yml and bashrc completion block ordering.
+install_cloud_clis_cli_installers:
+  - component: aws
+    label: AWS CLI
+    tasks_file: aws_cli.yml
+  - component: oc
+    label: OC CLI
+    tasks_file: oc_cli.yml
+  - component: ocm
+    label: OCM CLI
+    tasks_file: ocm_cli.yml
+  - component: rosa
+    label: ROSA CLI
+    tasks_file: rosa_cli.yml
+  - component: tekton
+    label: Tekton CLI
+    tasks_file: tekton_cli.yml
+  - component: kube_linter
+    label: kube-linter
+    tasks_file: kube-linter.yml
+  - component: kustomize
+    label: kustomize
+    tasks_file: kustomize.yml
+  - component: stern
+    label: stern
+    tasks_file: stern.yml
+  - component: helm
+    label: Helm
+    tasks_file: helm.yml
+  - component: gws
+    label: Google Workspace CLI
+    tasks_file: gws_cli.yml


### PR DESCRIPTION
## Summary

- Probe `mirror.openshift.com` for the newest GA ROSA build actually published before download, avoiding 404s when GitHub is ahead of the mirror.
- Loop CLI installs from `install_cloud_clis_cli_installers` with per-component `block`/`rescue` so one failure does not block remaining components.
- Document ROSA mirror behavior and install order in the role README.

## Test plan

- [ ] Run `ansible-playbook` with `install_cloud_clis_components: [rosa]` while GitHub latest is ahead of the mirror; confirm play succeeds and uses the newest mirror-available version.
- [ ] Run with multiple components (e.g. `rosa`, `gws`) and confirm all selected CLIs are attempted when one component fails.
- [ ] Verify skip messages appear in `install_cloud_clis_update_messages` when a component is rescued.


Made with [Cursor](https://cursor.com)