### PR TITLE
ci(dependabot): group updates and add pre-commit support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      ci-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
       ci-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Group all GitHub Actions dependency updates into a single PR instead of one per action
- Add Dependabot support for pre-commit hook updates, also grouped into a single PR

## Test plan
- [ ] Verify Dependabot picks up the new config and opens grouped PRs on the next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)