### PR TITLE
Prepare for 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,45 @@
 
 **Topics**
 
-- <a href="#v1-2-0">v1\.2\.0</a>
+- <a href="#v1-3-0">v1\.3\.0</a>
     - <a href="#release-summary">Release Summary</a>
     - <a href="#minor-changes">Minor Changes</a>
-    - <a href="#bugfixes">Bugfixes</a>
-- <a href="#v1-1-0">v1\.1\.0</a>
+- <a href="#v1-2-0">v1\.2\.0</a>
     - <a href="#release-summary-1">Release Summary</a>
     - <a href="#minor-changes-1">Minor Changes</a>
-- <a href="#v1-0-0">v1\.0\.0</a>
+    - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v1-1-0">v1\.1\.0</a>
     - <a href="#release-summary-2">Release Summary</a>
     - <a href="#minor-changes-2">Minor Changes</a>
+- <a href="#v1-0-0">v1\.0\.0</a>
+    - <a href="#release-summary-3">Release Summary</a>
+    - <a href="#minor-changes-3">Minor Changes</a>
     - <a href="#bugfixes-1">Bugfixes</a>
+
+<a id="v1-3-0"></a>
+## v1\.3\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+Improved shell startup performance by lazy\-loading and caching bash
+completions in the install\_cloud\_clis role\.
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* install\_cloud\_clis \- lazy\-load and cache bash completions to eliminate subprocess spawns at shell startup
 
 <a id="v1-2-0"></a>
 ## v1\.2\.0
 
-<a id="release-summary"></a>
+<a id="release-summary-1"></a>
 ### Release Summary
 
 Extends install\_cloud\_clis with OCM and Google Workspace CLIs\, hardens ROSA
 installs against mirror lag\, and isolates per\-CLI failures\.
 
-<a id="minor-changes"></a>
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * install\_cloud\_clis role \- add Google Workspace CLI \(gws\) installation from GitHub releases
@@ -39,12 +56,12 @@ installs against mirror lag\, and isolates per\-CLI failures\.
 <a id="v1-1-0"></a>
 ## v1\.1\.0
 
-<a id="release-summary-1"></a>
+<a id="release-summary-2"></a>
 ### Release Summary
 
 Feature release adding systemd unit management\, sysctl configuration\, and package replacement capabilities\.
 
-<a id="minor-changes-1"></a>
+<a id="minor-changes-2"></a>
 ### Minor Changes
 
 * Add <code>ansible\.posix</code> collection dependency\.
@@ -57,12 +74,12 @@ Feature release adding systemd unit management\, sysctl configuration\, and pack
 <a id="v1-0-0"></a>
 ## v1\.0\.0
 
-<a id="release-summary-2"></a>
+<a id="release-summary-3"></a>
 ### Release Summary
 
 Initial release of the collection
 
-<a id="minor-changes-2"></a>
+<a id="minor-changes-3"></a>
 ### Minor Changes
 
 * Add <code>openshift\_local</code> role to install or upgrade OpenShift Local \(CRC\) with optional host checks\, configurable <code>crc</code> settings\, and <code>\~/\.bashrc</code> completion\.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Branic System Management Collection Release Notes
 
 .. contents:: Topics
 
+v1.3.0
+======
+
+Release Summary
+---------------
+
+Improved shell startup performance by lazy-loading and caching bash
+completions in the install_cloud_clis role.
+
+Minor Changes
+-------------
+
+- install_cloud_clis - lazy-load and cache bash completions to eliminate subprocess spawns at shell startup
+
 v1.2.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -13,4 +13,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 1.2.0
+version: 1.3.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -128,3 +128,18 @@ releases:
       - install-cloud-clis-ocm-cli.yml
       - install-cloud-clis-rosa-mirror-probe.yml
     release_date: '2026-05-21'
+  1.3.0:
+    changes:
+      minor_changes:
+        - install_cloud_clis - lazy-load and cache bash completions to eliminate subprocess
+          spawns at shell startup
+      release_summary: 'Improved shell startup performance by lazy-loading and caching
+        bash
+
+        completions in the install_cloud_clis role.
+
+        '
+    fragments:
+      - lazy-load-bash-completions.yml
+      - release-summary.yml
+    release_date: '2026-06-15'

--- a/changelogs/fragments/lazy-load-bash-completions.yml
+++ b/changelogs/fragments/lazy-load-bash-completions.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - install_cloud_clis - lazy-load and cache bash completions to eliminate subprocess spawns at shell startup

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: "branic"
 name: "system_management"
-version: 1.2.0
+version: 1.3.0
 readme: README.md
 authors:
   - Brant Evans <bevans@redhat.com>


### PR DESCRIPTION
## Summary
- Bump version in `galaxy.yml` to 1.3.0
- Compile changelog with `antsibull-changelog release`

## Changes included in this release
- **Minor change:** install_cloud_clis — lazy-load and cache bash completions to eliminate subprocess spawns at shell startup

## Post-merge
After merging, create a GitHub Release with tag `v1.3.0` targeting `main` to trigger the Galaxy publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)